### PR TITLE
#14 comment 수정, 삭제, 조회 기능 풀 리퀘스트 요청합니다 Posts/comments

### DIFF
--- a/server/matp/src/main/java/com/matp/comment/controller/CommentController.java
+++ b/server/matp/src/main/java/com/matp/comment/controller/CommentController.java
@@ -1,13 +1,17 @@
 package com.matp.comment.controller;
 
+import com.matp.comment.dto.CommentInfo;
+import com.matp.comment.dto.CommentRequest;
 import com.matp.comment.dto.CommentResponse;
-import com.matp.comment.dto.PostCommentRequest;
 import com.matp.comment.service.CommentService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Mono;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -16,11 +20,31 @@ public class CommentController {
     private final CommentService commentService;
 
     @PostMapping
-    public Mono<ResponseEntity<CommentResponse>> createComment(@RequestBody Mono<PostCommentRequest> request,
+    public Mono<ResponseEntity<CommentResponse>> createComment(@Validated @RequestBody Mono<CommentRequest> request,
                                                                @PathVariable("post-id")Long postId) {
         Mono<ResponseEntity<CommentResponse>> map = request
-                .flatMap(saveCommentRequest -> commentService.save(saveCommentRequest,postId))
+                .flatMap(CommentRequest -> commentService.save(CommentRequest,postId))
                 .map(commentResponse -> new ResponseEntity<>(commentResponse, HttpStatus.CREATED));
         return map;
+    }
+    @PatchMapping("/{comment-id}")
+    public Mono<ResponseEntity<CommentResponse>> updateComment(@Validated @RequestBody Mono<CommentRequest> request,
+                                                               @PathVariable("post-id") Long postId,
+                                                               @PathVariable("comment-id") Long commentId) {
+        return request.flatMap(postCommentRequest -> commentService.updateComment(postCommentRequest, postId, commentId))
+                .map(commentResponse -> new ResponseEntity<>(commentResponse, HttpStatus.OK));
+    }
+
+    @DeleteMapping("/{comment-id}")
+    public Mono<ResponseEntity<Void>> deleteComment(@PathVariable("comment-id") Long commentId) {
+
+        return commentService.deleteComment(commentId).map(response -> ResponseEntity.noContent().build());
+    }
+
+    //TODO 특정 게시글의 댓글들 조회 ( 필요시 반영 )
+    @GetMapping("/comment-reload")
+    public Mono<ResponseEntity<List<CommentInfo>>> reloadComments(@PathVariable("post-id")Long postId) {
+        return commentService.getComments(postId)
+                .map(commentInfos -> new ResponseEntity<>(commentInfos,HttpStatus.OK));
     }
 }

--- a/server/matp/src/main/java/com/matp/comment/controller/CommentController.java
+++ b/server/matp/src/main/java/com/matp/comment/controller/CommentController.java
@@ -38,7 +38,9 @@ public class CommentController {
     @DeleteMapping("/{comment-id}")
     public Mono<ResponseEntity<Void>> deleteComment(@PathVariable("comment-id") Long commentId) {
 
-        return commentService.deleteComment(commentId).map(response -> ResponseEntity.noContent().build());
+        return commentService.deleteComment(commentId)
+                .map(response -> ResponseEntity.noContent().<Void>build())
+                .switchIfEmpty(Mono.just(new ResponseEntity<>(HttpStatus.NO_CONTENT)));
     }
 
     //TODO 특정 게시글의 댓글들 조회 ( 필요시 반영 )

--- a/server/matp/src/main/java/com/matp/comment/dto/CommentRequest.java
+++ b/server/matp/src/main/java/com/matp/comment/dto/CommentRequest.java
@@ -1,8 +1,9 @@
 package com.matp.comment.dto;
 
 import com.matp.comment.entity.Comment;
+import jakarta.validation.constraints.NotBlank;
 
-public record PostCommentRequest(String content) {
+public record CommentRequest(@NotBlank(message = " 댓글내용은 비어있을 수 없습니다")String content) {
     public Comment toEntity() {
         return Comment.builder()
                 .comment_content(content)

--- a/server/matp/src/main/java/com/matp/comment/dto/CommentSpecificInfo.java
+++ b/server/matp/src/main/java/com/matp/comment/dto/CommentSpecificInfo.java
@@ -2,5 +2,5 @@ package com.matp.comment.dto;
 
 import java.time.LocalDateTime;
 
-public record CommentSpecificInfo(Long id, Long feedId, Long userId, String commentContent, LocalDateTime commentCreatedAt, String nickname, String profileImg) {
+public record CommentSpecificInfo(Long id, Long postId, Long userId, String commentContent, LocalDateTime commentCreatedAt, String nickname, String profileImg) {
 }

--- a/server/matp/src/main/java/com/matp/comment/entity/Comment.java
+++ b/server/matp/src/main/java/com/matp/comment/entity/Comment.java
@@ -24,7 +24,7 @@ public class Comment {
 
     private Long userId;
 
-    private Long feedId;
+    private Long postId;
 
     @Transient
     private TestMember member;

--- a/server/matp/src/main/java/com/matp/comment/repository/CommentRepository.java
+++ b/server/matp/src/main/java/com/matp/comment/repository/CommentRepository.java
@@ -13,7 +13,7 @@ public interface CommentRepository extends ReactiveCrudRepository<Comment, Long>
     @Query("""
             SELECT
             pc.id,
-            pc.feed_id,
+            pc.post_id,
             pc.user_id,
             pc.comment_content,
             pc.comment_created_at,
@@ -22,7 +22,7 @@ public interface CommentRepository extends ReactiveCrudRepository<Comment, Long>
             FROM post_comment pc
             INNER JOIN member m
             ON pc.user_id = m.id
-            where pc.feed_id = :postId
+            where pc.post_id = :postId
            """)
     Flux<CommentSpecificInfo> findPost_CommentWithMember(Long PostId);
 

--- a/server/matp/src/main/java/com/matp/comment/repository/CommentRepository.java
+++ b/server/matp/src/main/java/com/matp/comment/repository/CommentRepository.java
@@ -21,6 +21,7 @@ public interface CommentRepository extends ReactiveCrudRepository<Comment, Long>
             m.profile_img
             FROM post_comment pc
             INNER JOIN member m
+            ON pc.user_id = m.id
             where pc.feed_id = :postId
            """)
     Flux<CommentSpecificInfo> findPost_CommentWithMember(Long PostId);

--- a/server/matp/src/main/java/com/matp/comment/service/CommentService.java
+++ b/server/matp/src/main/java/com/matp/comment/service/CommentService.java
@@ -16,6 +16,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class CommentService {
     private final CommentRepository commentRepository;
+
     public Mono<List<CommentInfo>> getComments(Long postId) {
         Mono<List<CommentInfo>> listMono = commentRepository.findPost_CommentWithMember(postId).map(commentSpecificInfo -> {
 
@@ -48,12 +49,12 @@ public class CommentService {
     public Mono<CommentResponse> updateComment(CommentRequest saveCommentRequest, Long postId, Long commentId) {
         Comment patchComment = saveCommentRequest.toEntity();
 
-        return commentRepository.findById(commentId).flatMap(comment -> {
-            comment.setId(commentId);
-            comment.setFeedId(postId);
-            comment.setComment_content(patchComment.getComment_content());
-            return commentRepository.save(comment);
-        }).map(CommentResponse::from);
+        return commentRepository.findById(commentId)
+                .flatMap(comment -> {
+                    comment.setComment_content(patchComment.getComment_content());
+                    return commentRepository.save(comment);
+                })
+                .map(CommentResponse::from);
 
     }
 

--- a/server/matp/src/main/java/com/matp/comment/service/CommentService.java
+++ b/server/matp/src/main/java/com/matp/comment/service/CommentService.java
@@ -1,8 +1,8 @@
 package com.matp.comment.service;
 
 import com.matp.comment.dto.CommentInfo;
+import com.matp.comment.dto.CommentRequest;
 import com.matp.comment.dto.CommentResponse;
-import com.matp.comment.dto.PostCommentRequest;
 import com.matp.comment.entity.Comment;
 import com.matp.comment.repository.CommentRepository;
 import com.matp.post.dto.testdto.PostMemberInfo;
@@ -35,7 +35,7 @@ public class CommentService {
         return listMono;
     }
 
-    public Mono<CommentResponse> save(PostCommentRequest saveCommentRequest, Long postId) {
+    public Mono<CommentResponse> save(CommentRequest saveCommentRequest, Long postId) {
 
         Comment postComment = saveCommentRequest.toEntity();
         postComment.setUserId(3L);
@@ -43,6 +43,22 @@ public class CommentService {
         Mono<Comment> save = commentRepository.save(postComment);
         Mono<CommentResponse> map = save.map(CommentResponse::from);
         return map;
+    }
+
+    public Mono<CommentResponse> updateComment(CommentRequest saveCommentRequest, Long postId, Long commentId) {
+        Comment patchComment = saveCommentRequest.toEntity();
+
+        return commentRepository.findById(commentId).flatMap(comment -> {
+            comment.setId(commentId);
+            comment.setFeedId(postId);
+            comment.setComment_content(patchComment.getComment_content());
+            return commentRepository.save(comment);
+        }).map(CommentResponse::from);
+
+    }
+
+    public Mono<Void> deleteComment(Long commentId) {
+        return commentRepository.deleteById(commentId);
     }
 
 }

--- a/server/matp/src/main/java/com/matp/comment/service/CommentService.java
+++ b/server/matp/src/main/java/com/matp/comment/service/CommentService.java
@@ -40,7 +40,7 @@ public class CommentService {
 
         Comment postComment = saveCommentRequest.toEntity();
         postComment.setUserId(3L);
-        postComment.setFeedId(postId);
+        postComment.setPostId(postId);
         Mono<Comment> save = commentRepository.save(postComment);
         Mono<CommentResponse> map = save.map(CommentResponse::from);
         return map;

--- a/server/matp/src/main/java/com/matp/post/repository/PostRepository.java
+++ b/server/matp/src/main/java/com/matp/post/repository/PostRepository.java
@@ -29,7 +29,8 @@ public interface PostRepository extends ReactiveCrudRepository<Post, Long> {
             p.created_at,
             p.modified_at,
             m.nickname,
-            m.profile_img FROM mat_post p
+            m.profile_img,
+            (select count(*) from post_likes pl where pl.post_id = :postId) as likes FROM mat_post p
             INNER JOIN member m
             ON p.member_id = m.id
             where p.id = :postId


### PR DESCRIPTION
## What is this PR?(작업 내용) :mag:
- 127c660302daf7c606d040adb3ea9287f5987565 CommentController, CommentService에 수정과 삭제 관련기능을 추가로 구현했습니다
-  bba15e0b34cbfb6ae4c18cc37d6f3c63897ee44c PostCommentRequest rerord 클래스 의 이름을 CommentRequest 로 변경했습니다
- Comment 관련 record 클래스들은 Post 기능 구현시 필요하여 이슈 #4 에 작성되었습니다.

## review point :memo:
-  ad0f79d79a21098220b3ce08adf762255cf7c8ba CommentController 의 deleteComment() 메서드의 HttpStatus 응답 관련하여 좋은 방법을 공유받고 싶습니다
-  

## Background(문제 배경) 🖼️ 
-  ad0f79d79a21098220b3ce08adf762255cf7c8ba CommentController 의 deleteComment() 메서드는 Mono<ResponseEntity< Void>> 를 리턴해주는데요,
-  HttpStatus 204 No_content 응답을 내려주기 위해 어떤 방식을 사용해야 할까요

## important(같이 논의할 내용) ❓ 
- 204응답을 내려주기위해 저는 아래의 방법들을 사용해보았습니다.
- 여러분은 착실히 공부하셔서 응답을 제대로 내려주시길 바랍니다..

```java
//[코드 - 1]
@DeleteMapping("/{comment-id}")
    public Mono<ResponseEntity<Void>> deleteComment(@PathVariable("comment-id") Long commentId) {

        Mono<ResponseEntity<Void>> map = commentService.deleteComment(commentId)
                .map(response -> ResponseEntity.noContent().build());
        return map;
    }
```
[코드 - 1] 에서 delete 요청을 보내면 200ok응답이 뜨더라구요.. void 에 대해 ResponseEntity를 붙이니(?) 안되는거라고 어림잡아 짐작 했습니다..

- 그래서 반환값이 없으면 없는대로(?!) 처리하면 되겠지 해서 밑의 방법을 시도해봤습니다.

```java
//[코드 - 2]
    @DeleteMapping("/{comment-id}")
    public Mono<Void> deleteComment(@PathVariable("comment-id") Long commentId) {

        return commentService.deleteComment(commentId)
                .switchIfEmpty(Mono.just(new ResponseEntity<>(HttpStatus.NO_CONTENT)).then());
    }
``` 
- [코드 - 2] 에선 switchIfEmpty로 반환값이 empty였을때 안의 로직을 수행하게 했습니다 . 

<br>

- [ TMI ] ※ 참고로 switchIfEmpty 를 사용할때는 주의할점이 한 가지 있습니다. 
   이름그대로 switchIfEmpty  라서 저처럼  '음~ 이름대로 empty일때 실행되는것같은데 ??? ' 라고 생각하실 수 있습니다.
   하지만 자바의 eager evaluation 전략( 메서드의 매개변수의 값을 미리 결정시켜놓으려는것 -해당 코드에선 switchIfEmpty( )안의 매개변수 값을 세팅하기위해 메서드가 무조건 실행됨 )으로 인한 불필요한 메서드 호출의 자원 낭비를 조심해야합니다 ~
   해결방법으로는 lazy 하게 처리해주는  Mono.defer() 를 사용하면 됩니다
   저는 #13 의 PostController 의 get요청들의 switchIfEmpty 에 defer() 를 사용했습니다. post를 못찾을때만 실행 되어야 하니까요~ . 

- [코드 - 2 ] 에서는 이런 부분을 신경쓰지 않아도( 왜냐면 delete하면 항상 비어있으니까..)된다고 판단해서 저렇게 작성해주었는데요.
<br>

~이렇게 지연로딩을 통해 자원을 아껴쓰면 어디선가 빵꾸가 나도 괜찮지않을까요? 농담입니다~

- switchifEmpty는 둘째치고  [코드 - 2 ]  도 200ok 응답을 내려주길래 생각하기를 포기하고(?)..

- 아래방법으로  임시로 해결했습니다..

```java
//[코드 - 3]
    @DeleteMapping("/{comment-id}")
    public Mono<ResponseEntity<Void>> deleteComment(@PathVariable("comment-id") Long commentId) {

        return commentService.deleteComment(commentId)
                .map(response -> ResponseEntity.noContent().<Void>build())
                .switchIfEmpty(Mono.just(new ResponseEntity<>(HttpStatus.NO_CONTENT)));
    }
``` 

- [코드 -3 ]에서 응답은 정상적으로 204 로 내려오는데 흠..  webflux를 많이 공부해봐야 할 것 같습니다.

- 🙏 프로젝트 일정에 맞추려고 구현에 급해서 파편적인 정보만 늘어나고 있네요 🙏

