### PR TITLE
#24 - Posts/likes 기능 풀 리퀘스트 입니다

### DIFF
--- a/server/matp/src/main/java/com/matp/comment/dto/CommentRequest.java
+++ b/server/matp/src/main/java/com/matp/comment/dto/CommentRequest.java
@@ -6,7 +6,7 @@ import jakarta.validation.constraints.NotBlank;
 public record CommentRequest(@NotBlank(message = " 댓글내용은 비어있을 수 없습니다")String content) {
     public Comment toEntity() {
         return Comment.builder()
-                .comment_content(content)
+                .commentContent(content)
                 .build();
     }
 }

--- a/server/matp/src/main/java/com/matp/comment/dto/CommentResponse.java
+++ b/server/matp/src/main/java/com/matp/comment/dto/CommentResponse.java
@@ -9,10 +9,10 @@ public record CommentResponse(Long id, String content, Long memberId, LocalDateT
     public static CommentResponse from(Comment comment) {
         return new CommentResponse(
                 comment.getId(),
-                comment.getComment_content(),
+                comment.getCommentContent(),
                 comment.getUserId(),
-                comment.getComment_createdAt(),
-                comment.getComment_modifiedAt()
+                comment.getCommentCreatedAt(),
+                comment.getCommentModifiedAt()
         );
     }
 }

--- a/server/matp/src/main/java/com/matp/comment/entity/Comment.java
+++ b/server/matp/src/main/java/com/matp/comment/entity/Comment.java
@@ -15,12 +15,11 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @Builder
 @Table(name = "post_comment")
-@Setter
 public class Comment {
     @Id
     private Long id;
 
-    private String comment_content;
+    private String commentContent;
 
     private Long userId;
 
@@ -30,8 +29,16 @@ public class Comment {
     private TestMember member;
 
     @CreatedDate
-    private LocalDateTime comment_createdAt;
+    private LocalDateTime commentCreatedAt;
 
     @LastModifiedDate
-    private LocalDateTime comment_modifiedAt;
+    private LocalDateTime commentModifiedAt;
+
+    public void updatePostId(Long postId) {
+        this.postId = postId;
+    }
+
+    public void patchComment(String commentContent) {
+        this.commentContent = commentContent;
+    }
 }

--- a/server/matp/src/main/java/com/matp/comment/repository/CommentRepository.java
+++ b/server/matp/src/main/java/com/matp/comment/repository/CommentRepository.java
@@ -24,6 +24,6 @@ public interface CommentRepository extends ReactiveCrudRepository<Comment, Long>
             ON pc.user_id = m.id
             where pc.post_id = :postId
            """)
-    Flux<CommentSpecificInfo> findPost_CommentWithMember(Long PostId);
+    Flux<CommentSpecificInfo> findPostCommentWithMember(Long PostId);
 
 }

--- a/server/matp/src/main/java/com/matp/likes/controller/LikesController.java
+++ b/server/matp/src/main/java/com/matp/likes/controller/LikesController.java
@@ -1,0 +1,31 @@
+package com.matp.likes.controller;
+
+import com.matp.likes.dto.LikesRequest;
+import com.matp.likes.service.LikesService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Mono;
+
+@RestController
+@RequestMapping("/places/posts/{post-id}/likes")
+@RequiredArgsConstructor
+public class LikesController {
+
+    private final LikesService likesService;
+
+    @PostMapping
+    public Mono<Void> createLikes(@RequestBody LikesRequest likeRequest,
+                                  @PathVariable("post-id") Long postId) {
+        //TODO member 구현시 member 정보 들어가야함
+        //TODO likes post 에서 불리언처리
+        Long memberId = 4L;
+        return likesService.increaseLikes(likeRequest, postId, memberId);
+    }
+
+    @DeleteMapping
+    public Mono<Void> deleteLikes(@PathVariable("post-id") Long postId) {
+        //TODO member 구현시 member 정보 들어가야함
+        Long memberId = 4L;
+        return likesService.decreaseLikes(postId,memberId);
+    }
+}

--- a/server/matp/src/main/java/com/matp/likes/dto/LikesRequest.java
+++ b/server/matp/src/main/java/com/matp/likes/dto/LikesRequest.java
@@ -1,0 +1,12 @@
+package com.matp.likes.dto;
+
+import com.matp.likes.entity.Likes;
+
+public record LikesRequest(int likesCheck) {
+
+    public Likes toEntity() {
+        return Likes.builder()
+                .likesCheck(likesCheck)
+                .build();
+    }
+}

--- a/server/matp/src/main/java/com/matp/likes/entity/Likes.java
+++ b/server/matp/src/main/java/com/matp/likes/entity/Likes.java
@@ -1,0 +1,33 @@
+package com.matp.likes.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Table;
+
+@Table("post_likes")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Likes {
+
+    @Id
+    private Long id;
+
+    private Long postId;
+
+    private Long placeId;
+
+    private Long userId;
+
+    private int likesCheck;
+
+    public void settingLikes(Long memberId, Long postId, int likesCheck) {
+        this.userId = memberId;
+        this.postId = postId;
+        this.likesCheck = likesCheck;
+    }
+}

--- a/server/matp/src/main/java/com/matp/likes/repository/LikesRepository.java
+++ b/server/matp/src/main/java/com/matp/likes/repository/LikesRepository.java
@@ -1,0 +1,37 @@
+package com.matp.likes.repository;
+
+import com.matp.likes.entity.Likes;
+import org.springframework.data.r2dbc.repository.Modifying;
+import org.springframework.data.r2dbc.repository.Query;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import reactor.core.publisher.Mono;
+
+public interface LikesRepository extends ReactiveCrudRepository<Likes, Long> {
+    @Query("""
+            select
+            l.id
+            from post_likes l
+            where l.post_id = :postId and l.user_id = :memberId
+            """)
+    Mono<Likes> findLikes(Long postId, Long memberId);
+
+    @Modifying
+    @Query("""
+            update
+            post p
+            set
+            p.likes = p.likes + 1
+            where p.id = :postId
+            """)
+    Mono<Void> increasePostLikesCount(Long postId);
+
+    @Modifying
+    @Query("""
+            update
+            post p
+            set
+            p.likes = p.likes - 1
+            where p.id = :postId
+            """)
+    Mono<Void> decreasePostLikesCount(Long PostId);
+}

--- a/server/matp/src/main/java/com/matp/likes/repository/LikesRepository.java
+++ b/server/matp/src/main/java/com/matp/likes/repository/LikesRepository.java
@@ -17,21 +17,34 @@ public interface LikesRepository extends ReactiveCrudRepository<Likes, Long> {
 
     @Modifying
     @Query("""
-            update
-            post p
-            set
-            p.likes = p.likes + 1
-            where p.id = :postId
+            insert into likes_count(likes, likes_post_id) values(likes + 1,:postId)
+            ON DUPLICATE KEY UPDATE likes = likes + 1
             """)
     Mono<Void> increasePostLikesCount(Long postId);
 
     @Modifying
     @Query("""
             update
-            post p
+            likes_count lc
             set
-            p.likes = p.likes - 1
-            where p.id = :postId
+            lc.likes = lc.likes - 1
+            where lc.likes_post_id = :postId
             """)
     Mono<Void> decreasePostLikesCount(Long PostId);
+
+    @Modifying
+    @Query("""
+            update post p
+            set
+            p.likes = :count
+            where p.id = :postId
+            """)
+    Mono<Void> updatePostLikes(Long postId,int count);
+
+    @Query("""
+            select likes
+            from likes_count lc
+            where lc.likes_post_id = :postId;
+            """)
+    Mono<Integer> getLikesCount(Long postId);
 }

--- a/server/matp/src/main/java/com/matp/likes/service/LikesService.java
+++ b/server/matp/src/main/java/com/matp/likes/service/LikesService.java
@@ -1,0 +1,36 @@
+package com.matp.likes.service;
+
+
+import com.matp.likes.dto.LikesRequest;
+import com.matp.likes.entity.Likes;
+import com.matp.likes.repository.LikesRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import reactor.core.publisher.Mono;
+
+@Service
+@RequiredArgsConstructor
+public class LikesService {
+
+    private final LikesRepository likesRepository;
+
+
+    @Transactional
+    public Mono<Void> increaseLikes(LikesRequest likeRequest, Long postId, Long memberId) {
+
+        Likes likes = likeRequest.toEntity();
+        likes.settingLikes(memberId,postId,likeRequest.likesCheck());
+
+        return likesRepository.save(likes)
+                .then(likesRepository.increasePostLikesCount(postId));
+
+    }
+    @Transactional
+    public Mono<Void> decreaseLikes(Long postId, Long memberId) {
+        //TODO 멤버 검증로직 들어가야함 .
+
+        return likesRepository.findLikes(postId, memberId).flatMap(likesRepository::delete)
+                .then(likesRepository.decreasePostLikesCount(postId));
+    }
+}

--- a/server/matp/src/main/java/com/matp/likes/service/LikesService.java
+++ b/server/matp/src/main/java/com/matp/likes/service/LikesService.java
@@ -23,7 +23,10 @@ public class LikesService {
         likes.settingLikes(memberId,postId,likeRequest.likesCheck());
 
         return likesRepository.save(likes)
-                .then(likesRepository.increasePostLikesCount(postId));
+                .then(likesRepository.increasePostLikesCount(postId))
+                .then(likesRepository.getLikesCount(postId)
+                        .flatMap(countInteger -> likesRepository.updatePostLikes(postId, countInteger.intValue()))
+                );
 
     }
     @Transactional
@@ -31,6 +34,9 @@ public class LikesService {
         //TODO 멤버 검증로직 들어가야함 .
 
         return likesRepository.findLikes(postId, memberId).flatMap(likesRepository::delete)
-                .then(likesRepository.decreasePostLikesCount(postId));
+                .then(likesRepository.decreasePostLikesCount(postId))
+                .then(likesRepository.getLikesCount(postId)
+                        .flatMap(countInteger -> likesRepository.updatePostLikes(postId, countInteger.intValue()))
+                );
     }
 }

--- a/server/matp/src/main/java/com/matp/post/dto/PatchPostRequest.java
+++ b/server/matp/src/main/java/com/matp/post/dto/PatchPostRequest.java
@@ -2,15 +2,15 @@ package com.matp.post.dto;
 
 import com.matp.post.entity.Post;
 
-public record PatchPostRequest(String title, String content, int star, String thumbnailUrl) {
+public record PatchPostRequest(String title, String content, String thumbnailUrl, int star) {
 
 
     public Post toEntity() {
         return Post.builder()
                 .title(title)
                 .content(content)
-                .star(star)
                 .thumbnailUrl(thumbnailUrl)
+                .star(star)
                 .build();
     }
 }

--- a/server/matp/src/main/java/com/matp/post/dto/PostRequest.java
+++ b/server/matp/src/main/java/com/matp/post/dto/PostRequest.java
@@ -4,14 +4,13 @@ import com.matp.post.entity.Post;
 import jakarta.validation.constraints.NotBlank;
 
 public record PostRequest(@NotBlank(message = "제목은 공백일 수 없습니다 !") String title, @NotBlank(message = "내용은 공백일 수 없습니다 !")String content,
-                                 int likes, String thumbnailUrl, int star) {
+                                 String thumbnailUrl, int star) {
 
 
     public Post toEntity() {
         return Post.builder()
                 .title(title)
                 .content(content)
-                .likes(likes)
                 .thumbnailUrl(thumbnailUrl)
                 .star(star)
                 .build();

--- a/server/matp/src/main/java/com/matp/post/entity/Post.java
+++ b/server/matp/src/main/java/com/matp/post/entity/Post.java
@@ -45,9 +45,6 @@ public class Post {
     @LastModifiedDate
     private LocalDateTime modifiedAt;
 
-    public void settingLikesCount(int count) {
-        this.likes = count;
-    }
     public Post settingPost(Post post, Post updatePost) {
         this.id = post.getId();
         this.title = updatePost.getTitle();

--- a/server/matp/src/main/java/com/matp/post/entity/Post.java
+++ b/server/matp/src/main/java/com/matp/post/entity/Post.java
@@ -48,12 +48,12 @@ public class Post {
     public void settingLikesCount(int count) {
         this.likes = count;
     }
-    public Post settingPost(Post post) {
-        this.title = post.getTitle();
-        this.content = post.getContent();
-        this.thumbnailUrl = post.getThumbnailUrl();
-        this.star = post.getStar();
+    public Post settingPost(Post post, Post updatePost) {
+        this.id = post.getId();
+        this.title = updatePost.getTitle();
+        this.content = updatePost.getContent();
+        this.thumbnailUrl = updatePost.getThumbnailUrl();
+        this.star = updatePost.getStar();
         return post;
     }
-
 }

--- a/server/matp/src/main/java/com/matp/post/entity/Post.java
+++ b/server/matp/src/main/java/com/matp/post/entity/Post.java
@@ -14,7 +14,6 @@ import java.util.List;
 @AllArgsConstructor
 @Builder
 @Table(name = "mat_post")
-@Setter
 public class Post {
 
     @Id
@@ -45,5 +44,16 @@ public class Post {
 
     @LastModifiedDate
     private LocalDateTime modifiedAt;
+
+    public void settingLikesCount(int count) {
+        this.likes = count;
+    }
+    public Post settingPost(Post post) {
+        this.title = post.getTitle();
+        this.content = post.getContent();
+        this.thumbnailUrl = post.getThumbnailUrl();
+        this.star = post.getStar();
+        return post;
+    }
 
 }

--- a/server/matp/src/main/java/com/matp/post/repository/PostRepository.java
+++ b/server/matp/src/main/java/com/matp/post/repository/PostRepository.java
@@ -26,11 +26,11 @@ public interface PostRepository extends ReactiveCrudRepository<Post, Long> {
             p.likes,
             p.thumbnail_url,
             p.star,
+            p.likes,
             p.created_at,
             p.modified_at,
             m.nickname,
             m.profile_img,
-            (select count(*) from post_likes pl where pl.post_id = :postId) as likes FROM mat_post p
             INNER JOIN member m
             ON p.member_id = m.id
             where p.id = :postId

--- a/server/matp/src/main/java/com/matp/post/repository/PostRepository.java
+++ b/server/matp/src/main/java/com/matp/post/repository/PostRepository.java
@@ -14,7 +14,12 @@ public interface PostRepository extends ReactiveCrudRepository<Post, Long> {
      * @author 임준건
      **/
     @Query("""
-            SELECT * FROM mat_post p WHERE p.title LIKE CONCAT('%', :keyword, '%') OR p.content LIKE CONCAT('%', :keyword, '%')
+            SELECT *
+            FROM post p
+            WHERE p.title
+            LIKE CONCAT('%', :keyword, '%')
+            OR p.content
+            LIKE CONCAT('%', :keyword, '%')
             """)
     Flux<Post> searchPostByKeyword(String keyword);
 
@@ -23,16 +28,17 @@ public interface PostRepository extends ReactiveCrudRepository<Post, Long> {
             p.id,
             p.title,
             p.content,
-            p.likes,
+            lc.likes,
             p.thumbnail_url,
             p.star,
-            p.likes,
             p.created_at,
             p.modified_at,
             m.nickname,
-            m.profile_img,
+            m.profile_img
+            FROM post p
             INNER JOIN member m
             ON p.member_id = m.id
+            join likes_count lc on lc.likes_post_id = p.id
             where p.id = :postId
             """)
     Mono<PostMemberSpecificInfo> findPostWithMemberInfo(Long postId);

--- a/server/matp/src/main/java/com/matp/post/service/PostService.java
+++ b/server/matp/src/main/java/com/matp/post/service/PostService.java
@@ -11,6 +11,8 @@ import com.matp.post.dto.testdto.PostMemberInfo;
 import com.matp.post.entity.Post;
 import com.matp.post.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.relational.core.sql.LockMode;
+import org.springframework.data.relational.repository.Lock;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import reactor.core.publisher.Flux;
@@ -66,12 +68,6 @@ public class PostService {
                             .modifiedAt(result.modifiedAt())
                             .memberInfo(member)
                             .build();
-                    postRepository.findById(postId)
-                            .map(findPost -> {
-                                findPost.settingLikesCount(result.likes());
-                                return findPost;
-                            })
-                            .flatMap(postRepository::save).subscribe();
                     return new MultiResponseDto(postResponseWithInfo, comments);
                 });
     }

--- a/server/matp/src/main/java/com/matp/post/service/PostService.java
+++ b/server/matp/src/main/java/com/matp/post/service/PostService.java
@@ -88,7 +88,7 @@ public class PostService {
     public Mono<PostResponse> save(PostRequest request) {
 
         Post Post = request.toEntity();
-        Post.setMemberId(2L);
+//        Post.setMemberId(2L);
 
         Mono<Post> save = PostRepository.save(Post);
 
@@ -101,15 +101,9 @@ public class PostService {
      * @author 임준건
      */
     public Mono<PostResponse> update(PatchPostRequest updatePostRequest, Long postId) {
-        Post Post = updatePostRequest.toEntity();
+        Post updatePost = updatePostRequest.toEntity();
 
-        return PostRepository.findById(postId).flatMap(post -> {
-            post.setTitle(Post.getTitle());
-            post.setContent(Post.getContent());
-            post.setThumbnailUrl(Post.getThumbnailUrl());
-            post.setStar(Post.getStar());
-            return PostRepository.save(post);
-        }).map(PostResponse::from);
+        return PostRepository.findById(postId).flatMap(post -> PostRepository.save(post.settingPost(updatePost))).map(PostResponse::from);
     }
 
     /**

--- a/server/matp/src/main/java/com/matp/post/service/PostService.java
+++ b/server/matp/src/main/java/com/matp/post/service/PostService.java
@@ -28,7 +28,7 @@ public class PostService {
      * @apiNote Post 를 {@link PostRepository} 에서 페이지네이션 해오는 메서드
      * @author 임준건
      */
-    @Transactional
+    @Transactional(readOnly = true)
     public Flux<PostResponse> getAll(int page,int size) {
 
         Flux<PostResponse> map = postRepository.findAll().skip(page * size).take(size).map(PostResponse::from);
@@ -41,7 +41,7 @@ public class PostService {
      * @apiNote 하나의 Post 를 {@link PostRepository} 에서 찾아오는 메서드
      * @author 임준건
      */
-    @Transactional
+    @Transactional(readOnly = true)
     public Mono<MultiResponseDto> getPost(Long postId) {
         return postRepository.findPostWithMemberInfo(postId)
                 .publishOn(Schedulers.boundedElastic())
@@ -80,7 +80,7 @@ public class PostService {
      * @apiNote keyword 로 Post 를 {@link PostRepository} 에서 찾아오는 메서드
      * @author 임준건
      */
-    @Transactional
+    @Transactional(readOnly = true)
     public Flux<PostResponse> findPostByKeyword(String keyword) {
 
         return postRepository.searchPostByKeyword(keyword)

--- a/server/matp/src/main/java/com/matp/post/service/PostService.java
+++ b/server/matp/src/main/java/com/matp/post/service/PostService.java
@@ -113,7 +113,7 @@ public class PostService {
     public Mono<PostResponse> update(PatchPostRequest updatePostRequest, Long postId) {
         Post updatePost = updatePostRequest.toEntity();
 
-        return postRepository.findById(postId).flatMap(post -> postRepository.save(post.settingPost(updatePost))).map(PostResponse::from);
+        return postRepository.findById(postId).flatMap(post -> postRepository.save(post.settingPost(post,updatePost))).map(PostResponse::from);
     }
 
     /**

--- a/server/matp/src/main/java/com/matp/post/service/PostService.java
+++ b/server/matp/src/main/java/com/matp/post/service/PostService.java
@@ -43,6 +43,7 @@ public class PostService {
      */
     @Transactional(readOnly = true)
     public Mono<MultiResponseDto> getPost(Long postId) {
+        // TODO Member 토큰 에서 memberID 뽑아서 좋아요 post 조회시에 체킹유무까지 넘겨줘야함
         return postRepository.findPostWithMemberInfo(postId)
                 .publishOn(Schedulers.boundedElastic())
                 .map(result -> {


### PR DESCRIPTION
## What is this PR?(작업 내용) :mag:
- Likes(좋아요) 기능을 구현하였습니다
- post요청으로 좋아요 등록가능합니다
- delete(patch로 변경가능성 있음)요청으로 해당 좋아요를 테이블에서 삭제하여 취소가 가능합니다

## review point :memo:
- 동시성 문제관련하여 이야기 나누어 보아야 할것같습니다
- 

## Background(문제 배경) 🖼️ 
- 동시성 문제를 해결하기 위해 update 쿼리로 해당하는 post의 likes row에 exclusive lock을 걸었습니다.
- 잘 했는지 모르겠습니다 .  봐주십쇼.. <- 포인트..


## important(같이 논의할 내용) ❓ 
- 테스트 코드를 작성해봤는데요
- 인생 첫 번째 테스트 코드가 동시성 문제 테스트 일거라곤 생각 못했기때문에 코드퀄리티는 양해 부탁드립니다
- 이렇게 접근하여 해결한 방식이 맞는지 리뷰 부탁드립니다.
-  likes 트랜잭션이  exclusive lock 을 걸었을 때 이 트랜잭션이 끝나기전까지 해당 row가( post row) lock에 걸려있어서 다른 트랜잭션이  update, delete 를 할 수 없다. 입니다..
- 결과는 밑에 사진 첨부하겠습니다.
- =========01.17부로 해결===========
```java
 //  v. 2023-01-17 testCode 업데이트
@Test
    void test() throws InterruptedException {

        ExecutorService executorService = Executors.newFixedThreadPool(3);
        CountDownLatch latch = new CountDownLatch(3);

        for (int i = 0 ; i < 30; i++ ) {
            executorService.execute(() -> {


                LikeRequest build = LikeRequest.builder().likesCheck(1).build();

                System.out.println("첫 번째 스레드 시작시간 : " + System.currentTimeMillis());
                System.out.println("첫 번째 스레드 시작시간(nanoTime) : " + System.nanoTime());
                likesRepository.increaseLikes(build,9L,1L).subscribe();

                latch.countDown();
            });

            executorService.execute(() -> {
                System.out.println("두 번째 스레드 시작시간 : " + System.currentTimeMillis());
                System.out.println("두 번째 스레드 시작시간(nanoTime) : " + System.nanoTime());
                SaveMatPostRequest build = SaveMatPostRequest.builder().title("te1st").content("te1st").star(1).thumbnailUrl("te1t").build();
                matPostService.save(build).subscribe();
                latch.countDown();
            });
            executorService.execute(() -> {


                LikeRequest build1 = LikeRequest.builder().likesCheck(1).build();

                System.out.println("세 번째 스레드 시작시간 : " + System.currentTimeMillis());
                System.out.println("세 번째 스레드 시작시간(nanoTime) : " + System.nanoTime());
                likesRepository.increaseLikes(build1,9L,2L).subscribe();

                latch.countDown();
            });
        }
        latch.await();

        MatPost block = matPostRepository.findById(9L).block();
        System.out.println( "27번째 게시물의 likes 숫자는 " + block.getLikes());
    }
```
## 실행결과 💾
![image](https://user-images.githubusercontent.com/73016277/212634663-6e732597-4606-4deb-8594-736b25e1a712.png)
![image](https://user-images.githubusercontent.com/73016277/212670830-6ebb59be-a2ca-400a-82e9-0d9669fa9b3e.png)


- 역시 예상대로...서로 베타락을 가지게 되는 matPostService.update 와 likesRepository.increasePostLikesCount 가 동시성 문제때문에 10번의 반복이면 해당 likes는 20이 되어야하는데 6이라는 값이 나오는걸 볼 수 있습니다..


===================================================================

- postId 와 likes의 숫자를 담고있는 테이블을 생성해서 문제를 해결했습니다.
- 테스트코드는 스레드 3개로 좋아요 증가, 게시물저장, 좋아요 증가 를 동시에 실행하는 로직을 30번 반복했습니다.
- 테스트는  save요청 30개가 온전하게 모두 저장되고 , 9번 게시물에 좋아요가 60개가 온전히 DB에  저장되는지를 중점으로 봤습니다.
=== 테스트 실행 전 ===
- 9번게시물의 좋아요 0개
![image](https://user-images.githubusercontent.com/73016277/212869857-319bc65e-7b14-441e-b4c4-26015e63dd85.png)
- like 정보를 저장하는 post_likes 테이블입니다 .
![image](https://user-images.githubusercontent.com/73016277/212870028-b01c3c78-4e77-4618-871b-39fa50968cca.png)
- likesCount를 저장하는 likes_count 테이블입니다
![image](https://user-images.githubusercontent.com/73016277/212870521-48ac92f4-e72c-46e1-bf9e-5b35172cdaad.png)

=== 실행 후 ===
- 9번게시물의 좋아요가 60개가 되었습니다. 생성된 게시물은 241번부터
![image](https://user-images.githubusercontent.com/73016277/212871139-6d9e94f4-fdc8-4030-aa97-d876bbc0fb67.png)
- 270개로 테스트 코드대로 30개의 요청 전부 생성되었습니다.
![image](https://user-images.githubusercontent.com/73016277/212871322-5146345a-60c7-4eb8-b926-51b6120c8422.png)
- post_likes 테이블도 60개의 좋아요 가 모두 생성되었습니다.
![image](https://user-images.githubusercontent.com/73016277/212871520-bc206d0b-e278-4ed3-854c-501bd17fa897.png)
- likes_count 도 60개 의 증가요청을 모두 손실없이 받아왔습니다
![image](https://user-images.githubusercontent.com/73016277/212871813-000d8716-f028-40b1-bdbb-c09a5eb39f7b.png)


## ====== 정리 및 한계점 🔨 =======
문제상황 : 좋아요 증가요청이 동시에 왔을 때 갱신 손실이 일어났습니다.(둘 중 한개만 반영 ex. 두 명이 같은시간에 눌렀을때 '1' 만(한개의 요청만) 올라감)
->해결 선택지는 다양했습니다.
비관적 락 의경우 메서드에 @lock어노테이션을 걸었을때 메서드 시작순간부터 베타 락 상태에 들어가기 때문에 동시에 접근하는 트랜잭션이 많아졌을댄 대기시간이 많이 증가할것이라 생각하였고, 또한
애플리케이션 레벨에서 명시적인 락을 걸었을때 db자체적인 lock과 더불어 예상못한 사이드이펙트를 불러올수있다고 판단하였고, 트랜잭션에 대한 이해가 충분하지 못한상황에서 사용하는것은 무리라고판단하여 후순위 선택지로 미뤘습니다.
낙관적 락의 경우 entity의 필드에 @version을 이용해서 버전이 다를경우 롤백처리를 하는데 이후 사용할 방법과 비교해봤을때 비즈니스 로직을 수정하기에는 시간이 없다고 판단하여 후순위로 미루었습니다
분산 락의 경우 redisson이나, mysql 의 namedlock 을 구현해서 문제를 해결할 수 있었지만 시간비용이 많이들고 redisson의 경우 마찬가지로 프로젝트 규모상 좋아요 기능 하나만을 위해 해당 의존성을 추가하는건 해당 지식을 공부할 시간적 비용이 많지않다고판단했습니다.
rabbitmq를 사용해서 Event-Driven방식으로 요청을 mq에서 구독하여 해결하는 방법도 있었으나 전체적인 로직을 다시짜야하고, 해당 mq서비스를 공부할 시간적 여유가 없었기에 후순위로 미루었습니다.
스케쥴러를 통해 궁극적 일관성을 보장하는 방법도 고려해봤으나. 좋아요 같은 실시간으로 게시물의 좋아요수를 확인하는 시스템의
목적이 희미해 질것같아서 후순위로 미루었습니다.
따라서 update 쿼리를 통한 DB 자체적으로 걸어주는 베타 락 을 이용해서 해결하는 방법을 시도하였습니다.
 mysql에서 update 는 트랜잭션이 끝나고 락을 해제하기 전까지 베타 락(Exclusive Lock, X-Lock ,다른 세션이 해당자원에 접근하는것을 막음.
mysql에서 이 베타 락의 row에는 조회 트랜잭션은 접근이 가능하다.)을 얻게됩니다.
따라서 저는 좋아요 증가요청의 동시성 제어를 위해
post에있는 likes 테이블에 update쿼리를 날려서 베타락을 얻게한다음
다른 트랜잭션이(좋아요 증가 트랜잭션)이 락을 풀기전까지는 접근못하게 해서 트랜잭션을 커밋합니다.
update가 끝난후에는 x-lock획득에 실패해서
 x-lock획득을 대기하고 있던 다른 좋아요 요청이 x-lock을 획득하고 커밋하여 update하는 방식으로 
동시성을 제어하는데에 성공했습니다. ,
서로 자원공유 문제는 없기때문에 데드락 문제도 피할 수 있었습니다. 
하지만 like의 숫자를 증가시키려는 update쿼리와
게시글을 수정하는(update 쿼리) 트랜잭션이 동시에 일어날경우 트랜잭션간 충돌이 일어나서
둘 중 하나의 트랜잭션은 롤백이 되어서 요청이 처리가 되지않게되는걸 테스트코드로 확인했습니다.
(산넘어 산)
따라서 저는 post의 likes컬럼과 likes식별을 위한 postid값을 가진 like_count테이블을 생성해서
update시에 post의 해당row에 x-lock이 걸리는 걸 회피하는 방식을 택했습니다.
이렇게 구현하고 난뒤에 likes_count에 어떻게 postid의 likes정보를 넣어야하나
고민에 빠졌습니다. 포스트 등록시에 likes_count테이블에 row를 추가하자니,
원래 게시글 테이블의 postid가 Auto increament 였기때문에 같이 넣을수도없고,
그러던중 upsert[ insert+ update]를 구글링도중 찾았고,
해당 sql문은 값이없으면 넣고, 키값이 같았을경우 원하는 값을 update할수있는
좋은 친구였습니다.
따라서 해당방법으로 likes_count테이블에 성공적으로 해당postId의 row를 추가할수있었습니다.
그 후에 getALL요청시에 다른 테이블에 있는 likes의 숫자를 어떻게 모든게시물에 넣을건지가 다음 문제였습니다.
저는 좋아요 숫자를 post의 get요청에 likes를 넣어주기위해 껍데기만 있는 post.likes 컬럼에 
likes_count.likes의 숫자를 넣어주는 쿼리문을 작성하였고 해당 쿼리문은 select 이기때문에 mysql에선
베타락()에 걸린 row여도 정보 조회에는(SELECT)제약이 없기 때문에 likes_count.likes를 가져오는데에는 문제가없었습니다.
가져온 likes숫자를 stream 처리하여 첫번째의 likes_count.likes의 UPDATE 요청과 동일한 트랜잭션(베타락을 보장받는)에서 post.likes를 
update할 수 있었습니다.
이후 테스트 결과 save,update 요청을 두 개의 likes 증가 요청과 동시에 실행시킨 결과
모두 갱신손실 없이 정상적으로 db에 반영되어 문제를 해결할수있었습니다.
한계점으로는 쓰인 sql문이 특정 DB(mysql) 에 종속되어있다는게 한계점입니다.
매번 좋아요 요청시 업데이트를위해 DB에 접근해야하는데 캐시레이어를 도입해서(할수있을진 모르겠지만 생각상으로는)
좀더 효율적으로 I/O시간을 줄일 수 있을것같습니다.

감사합니다 🙏