### PR TITLE
#47 - 피커 CRUD 기능 

### DIFF
--- a/server/matp/src/main/java/com/matp/group/controller/GroupController.java
+++ b/server/matp/src/main/java/com/matp/group/controller/GroupController.java
@@ -1,0 +1,45 @@
+package com.matp.group.controller;
+
+import com.matp.group.dto.GroupRequestDto;
+import com.matp.group.dto.GroupResponseDto;
+import com.matp.group.service.GroupService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/groups")
+public class GroupController {
+    private final GroupService groupService;
+
+    // 모든 기능 멤버 아이디값 가져와야됨
+    @PostMapping
+    public Mono<ResponseEntity<GroupResponseDto>> postGroup(@RequestBody Mono<GroupRequestDto> groupPostDto) {
+        return groupPostDto.flatMap(dto -> groupService.createGroup(dto, 1L))
+                .map(response -> new ResponseEntity<>(response, HttpStatus.CREATED));
+    }
+
+
+    @PatchMapping("/{group-id}")
+    public Mono<ResponseEntity<GroupResponseDto>> patchGroup(@PathVariable("group-id") Long groupId, @RequestBody Mono<GroupRequestDto> groupPatchDto) {
+        return groupPatchDto.flatMap((GroupRequestDto dto) -> groupService.updateGroup(dto, groupId, 1L))
+                .map(response -> new ResponseEntity<>(response, HttpStatus.OK));
+    }
+
+
+    @GetMapping
+    public Flux<GroupResponseDto> getGroups() {
+        return groupService.findGroups(1L);
+    }
+
+
+    @DeleteMapping("/{group-id}")
+    public Mono<ResponseEntity<Void>> deleteGroup(@PathVariable("group-id") Long groupId) {
+        return groupService.deleteGroup(groupId, 1L)
+                .map(response -> ResponseEntity.noContent().build());
+    }
+}

--- a/server/matp/src/main/java/com/matp/group/dto/GroupRequestDto.java
+++ b/server/matp/src/main/java/com/matp/group/dto/GroupRequestDto.java
@@ -1,0 +1,17 @@
+package com.matp.group.dto;
+
+import com.matp.group.entity.Group;
+
+import java.time.LocalDateTime;
+
+public record GroupRequestDto(String name, int groupImgIndex) {
+    public Group of(Long memberId) {
+        return Group.builder()
+                .name(name)
+                .groupImgIndex(groupImgIndex)
+                .memberId(memberId)
+                .createdAt(LocalDateTime.now())
+                .modifiedAt(LocalDateTime.now())
+                .build();
+    }
+}

--- a/server/matp/src/main/java/com/matp/group/dto/GroupResponseDto.java
+++ b/server/matp/src/main/java/com/matp/group/dto/GroupResponseDto.java
@@ -1,0 +1,15 @@
+package com.matp.group.dto;
+
+import com.matp.group.entity.Group;
+import lombok.Builder;
+
+@Builder
+public record GroupResponseDto(Long id, String name, int groupImgIndex) {
+    public static GroupResponseDto of(Group group) {
+        return GroupResponseDto.builder()
+                .id(group.getId())
+                .name(group.getName())
+                .groupImgIndex(group.getGroupImgIndex())
+                .build();
+    }
+}

--- a/server/matp/src/main/java/com/matp/group/entity/Group.java
+++ b/server/matp/src/main/java/com/matp/group/entity/Group.java
@@ -1,0 +1,30 @@
+package com.matp.group.entity;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.relational.core.mapping.Table;
+
+import java.time.LocalDateTime;
+
+@Builder
+@Getter
+@Table("picker_group")
+public class Group {
+    @Id
+    private Long id;
+
+    private String name;
+
+    private int groupImgIndex;
+
+    private Long memberId;
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime modifiedAt;
+}

--- a/server/matp/src/main/java/com/matp/group/repository/GroupRepository.java
+++ b/server/matp/src/main/java/com/matp/group/repository/GroupRepository.java
@@ -1,0 +1,24 @@
+package com.matp.group.repository;
+
+import com.matp.group.entity.Group;
+import org.springframework.data.r2dbc.repository.Query;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+public interface GroupRepository extends ReactiveCrudRepository<Group, Long> {
+
+    @Query("""
+        SELECT id, name, group_img_index
+        FROM picker_group
+        WHERE member_id = :memberId
+    """)
+    Flux<Group> findAllByMemberId(long memberId);
+
+    @Query("""
+        SELECT id, name, group_img_index
+        FROM picker_group
+        WHERE member_id = :memberId and id = :groupId
+    """)
+    Mono<Group> findByIds(Long groupId, Long memberId);
+}

--- a/server/matp/src/main/java/com/matp/group/service/GroupService.java
+++ b/server/matp/src/main/java/com/matp/group/service/GroupService.java
@@ -1,0 +1,54 @@
+package com.matp.group.service;
+
+import com.matp.group.dto.GroupRequestDto;
+import com.matp.group.dto.GroupResponseDto;
+import com.matp.group.entity.Group;
+import com.matp.group.repository.GroupRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class GroupService {
+    private final GroupRepository groupRepository;
+
+    @Transactional
+    public Mono<GroupResponseDto> createGroup(GroupRequestDto groupRequestDto, Long memberId) {
+        Mono<Group> group = groupRepository.save(groupRequestDto.of(memberId));
+        return group.map(GroupResponseDto::of);
+    }
+    // 멤버 아이디 받아와서 같은지 확인하는 로직 필요함
+    @Transactional
+    public Mono<GroupResponseDto> updateGroup(GroupRequestDto groupRequestDto, Long groupId, Long memberId) {
+        Mono<Group> findGroup = groupRepository.findByIds(groupId, memberId)
+                .map(group ->
+                        Group.builder()
+                                .id(groupId)
+                                .name(groupRequestDto.name() == null ? group.getName() : groupRequestDto.name())
+                                .groupImgIndex(groupRequestDto.groupImgIndex() == 0 ? group.getGroupImgIndex() : groupRequestDto.groupImgIndex())
+                                .createdAt(group.getCreatedAt())
+                                .modifiedAt(LocalDateTime.now())
+                                .memberId(group.getMemberId())
+                                .build());
+        return findGroup.flatMap(group -> groupRepository.save(group).map(GroupResponseDto::of));
+    }
+
+    @Transactional(readOnly = true)
+    public Flux<GroupResponseDto> findGroups(Long memberId) {
+        return groupRepository.findAllByMemberId(memberId).map(GroupResponseDto::of);
+    }
+
+
+    // 전체 갯수가 하나면 삭제 못하게 막아야됨
+    // 삭제할 groupId를 가진 group이 존재해야함 -> 존재하지않아도 에러발생안함
+    // 삭제하려는사람과 삭제될 그룹의 memberId 같은지 확인해야됨
+    @Transactional
+    public Mono<Void> deleteGroup(Long groupId, Long memberId) {
+        return  groupRepository.findByIds(groupId, memberId).flatMap(groupRepository::delete);
+    }
+}
+


### PR DESCRIPTION
멤버 아이디를 이용하여 피커 그룹을 생성, 조회, 수정, 삭제 합니다

## What is this PR?(작업 내용) :mag:
피커 그룹 CRUD
- 생성 : 사용자로부터 name과 groupImgIndex받아와 memberId와 함께 저장합니다
- 조회 : 사용자가 생성한 그룹들을 조회합니다
- 수정 : 사용자의 그룹을 name과 groupImgIndex를 받아와 memberId가 동일하면 수정합니다
- 삭제 : 사용자의 그룹에서 groupId와 memberId를 이용하여 해당 그룹을 삭제합니다

## review point :memo:
- 
- 

## Background(문제 배경) 🖼️ 
- 현재 erd의 group 테이블에 memberId를 외래키로 설정했는데 Request Header로 넘어오는 로그인유저 정보는 이메일입니다 모든 기능이 memberId와 비교해야해서 이메일로 유저 찾은다음에 아이디 가져오는 과정을 진행해야합니다

- 에러 처리
수정과 삭제 기능에서 수정 권한이 없는 사용자가 그룹을 삭제하려고 할 때 삭제는 안되지만 200 OK response를 반환합니다
또, 삭제가 완료됐을 때와 삭제할 그룹이 없을 때 또한 마찬가지로 200 OK response를 반환합니다



## important(같이 논의할 내용) ❓ 
- column 값을 memberId에서 email로 변경하여 해결할 것인가 아니면 Request Header로 넘어오는 정보에 Id값을 포함시킬 것인지 논의가 필요합니다

- 에러 처리 모듈화 관련 논의가 필요합니다
