### PR TITLE
Feature/user

### DIFF
--- a/server/matp/build.gradle
+++ b/server/matp/build.gradle
@@ -19,6 +19,12 @@ repositories {
 }
 
 dependencies {
+	//OAuth2
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
+	//security
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+
 	//spring
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
@@ -41,8 +47,14 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 
 	//test
+	testImplementation 'org.springframework.security:spring-security-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'io.projectreactor:reactor-test'
+
+	//jwt
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly	'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 tasks.named('test') {

--- a/server/matp/src/main/java/com/matp/auth/config/SecurityConfig.java
+++ b/server/matp/src/main/java/com/matp/auth/config/SecurityConfig.java
@@ -1,0 +1,123 @@
+package com.matp.auth.config;
+
+import com.matp.auth.dto.GoogleOAuth2Response;
+import com.matp.auth.dto.KakaoOAuth2Response;
+import com.matp.auth.dto.MemberPrincipal;
+import com.matp.auth.handler.OAuthSuccessHandler;
+import com.matp.auth.jwt.JwtAuthenticationFilter;
+import com.matp.auth.jwt.JwtTokenProvider;
+import com.matp.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
+import org.springframework.security.config.web.server.SecurityWebFiltersOrder;
+import org.springframework.security.config.web.server.ServerHttpSecurity;
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcReactiveOAuth2UserService;
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest;
+import org.springframework.security.oauth2.client.userinfo.DefaultReactiveOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.ReactiveOAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticatedPrincipal;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.server.SecurityWebFilterChain;
+import org.springframework.security.web.server.context.NoOpServerSecurityContextRepository;
+import reactor.core.publisher.Mono;
+
+
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+@EnableWebFluxSecurity
+public class SecurityConfig {
+    private final JwtTokenProvider jwtTokenProvider;
+
+    /**
+     * 리액티브(webflux)에서는 ServerHttpSecurity사용
+     * OAuth2 로그인에 성공시 핸들러에서 토크을 발급한다
+     * 매 요텅마다 검증하기위해 addfilterAt에서 HTTP_BASIC에 걸어둠
+     */
+    @Bean
+    public SecurityWebFilterChain configure(ServerHttpSecurity http) throws Exception {
+        return http
+                .csrf().disable()
+                .formLogin().disable()
+                .httpBasic().disable()
+                .authorizeExchange(auth -> auth
+                        .pathMatchers(HttpMethod.DELETE, "/members/**").permitAll() // 임시
+                        .pathMatchers("/login").permitAll()
+                        .anyExchange().authenticated()
+                )
+                .securityContextRepository(NoOpServerSecurityContextRepository.getInstance()) // stateless
+                .oauth2Login(oauth -> oauth.authenticationSuccessHandler(new OAuthSuccessHandler(jwtTokenProvider)))
+                /*.exceptionHandling(exceptionHandlingSpec -> exceptionHandlingSpec
+                        .authenticationEntryPoint((exchange, ex) -> {
+                            return Mono.fromRunnable(() -> {
+                                exchange.getResponse().setStatusCode(HttpStatus.UNAUTHORIZED);
+                            });
+                        })
+                        .accessDeniedHandler((exchange, denied) -> {
+                            return Mono.fromRunnable(() -> {
+                                exchange.getResponse().setStatusCode(HttpStatus.FORBIDDEN);
+                            });
+                        }))*/
+                .exceptionHandling(exceptionHandlingSpec -> exceptionHandlingSpec.accessDeniedHandler((exchange, exception) -> Mono.error(new RuntimeException("접근 권한 없음"))))
+                .addFilterAt(new JwtAuthenticationFilter(jwtTokenProvider), SecurityWebFiltersOrder.HTTP_BASIC)
+                .build();
+    }
+
+    /**
+     * ReactiveOAuth2UserService를 사용하여 로그인시 가져온 유저 정보를 토대로 MemberPrincipal로 변환하여 반환한다
+     * 구글 로그인은 OidcUser를 반환
+     * 데이터베이스에 유저 정보가 등록되어있지 않다면 추가
+     */
+    @Bean
+    public ReactiveOAuth2UserService<OidcUserRequest, OidcUser> oidcOAuth2UserService(MemberService memberService) {
+        final OidcReactiveOAuth2UserService delegate = new OidcReactiveOAuth2UserService();
+
+        return userRequest -> {
+            Mono<OidcUser> oidcUser = delegate.loadUser(userRequest);
+            String registrationId = userRequest.getClientRegistration().getRegistrationId();
+
+            return oidcUser
+                    .map(OAuth2AuthenticatedPrincipal::getAttributes)
+                    .map(GoogleOAuth2Response::from)
+                    .map(GoogleOAuth2Response::toPrincipal)
+                    .flatMap(principal -> {
+                        return memberService.findMember(principal.email())
+                                .switchIfEmpty(memberService.saveMember(principal.toDto(registrationId)))
+                                .map(MemberPrincipal::from);
+                    });
+        };
+    }
+
+
+    /**
+     * ReactiveOAuth2UserService를 사용하여 로그인시 가져온 유저 정보를 토대로 MemberPrincipal로 변환하여 반환한다
+     * 카카오 로그인은 OAuth2User를 반환
+     * 데이터베이스에 유저 정보가 등록되어있지 않다면 추가
+     */
+    @Bean
+    public ReactiveOAuth2UserService<OAuth2UserRequest, OAuth2User> oAuth2UserService(MemberService memberService) {
+        final DefaultReactiveOAuth2UserService delegate = new DefaultReactiveOAuth2UserService();
+
+        return userRequest -> {
+            Mono<OAuth2User> oAuth2User = delegate.loadUser(userRequest);
+            String registrationId = userRequest.getClientRegistration().getRegistrationId();
+
+            return oAuth2User
+                    .map(OAuth2AuthenticatedPrincipal::getAttributes)
+                    .map(KakaoOAuth2Response::from)
+                    .map(KakaoOAuth2Response::toPrincipal)
+                    .flatMap(principal -> {
+                        return memberService.findMember(principal.email())
+                                .switchIfEmpty(memberService.saveMember(principal.toDto(registrationId)))
+                                .map(MemberPrincipal::from);
+                    });
+        };
+    }
+
+}

--- a/server/matp/src/main/java/com/matp/auth/dto/GoogleOAuth2Response.java
+++ b/server/matp/src/main/java/com/matp/auth/dto/GoogleOAuth2Response.java
@@ -1,0 +1,33 @@
+package com.matp.auth.dto;
+
+import java.util.Map;
+
+/**
+ * 구글 유저 정보를 바탕으로 필요한 정보만 매핑
+ */
+@SuppressWarnings("unchecked")
+public record GoogleOAuth2Response(
+        String email,
+        String nickname,
+        String profileUrl
+) {
+    public static GoogleOAuth2Response from(Map<String, Object> attributes) {
+        return new GoogleOAuth2Response(
+                String.valueOf(attributes.get("email")),
+                String.valueOf(attributes.get("name")),
+                String.valueOf(attributes.get("picture"))
+        );
+    }
+
+    public MemberPrincipal toPrincipal() {
+        return MemberPrincipal.of(
+                email,
+                nickname,
+                null,
+                null,
+                profileUrl,
+                null
+        );
+    }
+
+}

--- a/server/matp/src/main/java/com/matp/auth/dto/KakaoOAuth2Response.java
+++ b/server/matp/src/main/java/com/matp/auth/dto/KakaoOAuth2Response.java
@@ -1,0 +1,65 @@
+package com.matp.auth.dto;
+
+import java.util.Map;
+
+/**
+ * 카카오 유저 정보를 바탕으로 필요한 정보만 매핑
+ */
+@SuppressWarnings("unchecked")
+public record KakaoOAuth2Response(
+        Long id,
+        KakaoAccount kakaoAccount
+) {
+    public record KakaoAccount(
+            Profile profile,
+            String email,
+            String birthday,
+            Integer gender
+    ) {
+        public record Profile(String nickname, String profileUrl) {
+            public static Profile from(Map<String, Object> attributes) {
+                return new Profile(
+                        String.valueOf(attributes.get("nickname")),
+                        String.valueOf(attributes.get("profile_image_url"))
+                );
+            }
+        }
+
+        public static KakaoAccount from(Map<String, Object> attributes) {
+            Integer gender;
+            if (attributes.get("gender").equals("male")) gender = 1;
+            else gender = 0;
+
+            return new KakaoAccount(
+                    Profile.from((Map<String, Object>) attributes.get("profile")),
+                    String.valueOf(attributes.get("email")),
+                    String.valueOf(attributes.get("birthday")),
+                    gender
+            );
+        }
+
+        public String nickname() { return this.profile().nickname(); }
+    }
+
+    public static KakaoOAuth2Response from(Map<String, Object> attributes) {
+        return new KakaoOAuth2Response(
+                Long.valueOf(String.valueOf(attributes.get("id"))),
+                KakaoAccount.from((Map<String, Object>) attributes.get("kakao_account"))
+        );
+    }
+
+    public MemberPrincipal toPrincipal() {
+        return MemberPrincipal.of(
+                kakaoAccount.email,
+                kakaoAccount.profile.nickname,
+                kakaoAccount.birthday,
+                kakaoAccount.gender,
+                kakaoAccount.profile.profileUrl,
+                null
+        );
+    }
+
+    public String email() { return this.kakaoAccount().email(); }
+    public String nickname() { return this.kakaoAccount().nickname(); }
+
+}

--- a/server/matp/src/main/java/com/matp/auth/dto/MemberPrincipal.java
+++ b/server/matp/src/main/java/com/matp/auth/dto/MemberPrincipal.java
@@ -1,0 +1,99 @@
+package com.matp.auth.dto;
+
+import com.matp.member.dto.MemberDto;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.OidcUserInfo;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * 구글과 카카오의 인증객체를 담기위해 OAuth2User, OidcUser를 모두 구현
+ * 인증시 넘어온 authentication객체가 MemberPrincipal로 매핑됨
+ */
+public record MemberPrincipal(
+        String email,
+        String nickname,
+        String birthday,
+        Integer gender,
+        String profileUrl,
+        String memo,
+        Collection<? extends GrantedAuthority> authorities,
+        Map<String, Object> oAuth2Attributes
+) implements OAuth2User, OidcUser {
+    public static MemberPrincipal of(String email, Collection<? extends GrantedAuthority> authorities) {
+        return new MemberPrincipal(email, null, null, null, null, null, authorities, Map.of());
+    }
+
+    public static MemberPrincipal of(String email, String nickname, String birthday, Integer gender, String profileUrl, String memo) {
+        return of(email, nickname, birthday, gender, profileUrl, memo, Map.of());
+    }
+
+    public static MemberPrincipal of(String email, String nickname, String birthday, Integer gender, String profileUrl, String memo, Map<String, Object> oAuth2Attributes) {
+        Set<RoleType> roleTypes = Set.of(RoleType.USER);
+
+        return new MemberPrincipal(
+                email,
+                nickname,
+                birthday,
+                gender,
+                profileUrl,
+                memo,
+                roleTypes.stream()
+                        .map(RoleType::getName)
+                        .map(SimpleGrantedAuthority::new)
+                        .collect(Collectors.toUnmodifiableSet()),
+                oAuth2Attributes
+        );
+    }
+
+    public static MemberPrincipal from(MemberDto dto) {
+        return MemberPrincipal.of(
+                dto.email(),
+                dto.nickname(),
+                dto.birthday(),
+                dto.gender(),
+                dto.profileUrl(),
+                dto.memo()
+        );
+    }
+
+    public MemberDto toDto(String registrationId) {
+        return MemberDto.of(
+                email,
+                nickname,
+                birthday,
+                profileUrl,
+                gender,
+                memo,
+                registrationId
+        );
+    }
+
+    @Override public Map<String, Object> getAttributes() { return oAuth2Attributes; }
+    @Override public Collection<? extends GrantedAuthority> getAuthorities() { return authorities; }
+    @Override public String getName() { return nickname; }
+
+    @Override public Map<String, Object> getClaims() { return oAuth2Attributes; }
+    @Override public OidcUserInfo getUserInfo() { return null; }
+    @Override public OidcIdToken getIdToken() { return null; }
+
+    public enum RoleType {
+        USER("ROLE_USER");
+
+        @Getter
+        private final String name;
+
+        RoleType(String name) {
+            this.name = name;
+        }
+    }
+
+}

--- a/server/matp/src/main/java/com/matp/auth/handler/OAuthSuccessHandler.java
+++ b/server/matp/src/main/java/com/matp/auth/handler/OAuthSuccessHandler.java
@@ -1,0 +1,82 @@
+package com.matp.auth.handler;
+
+import com.matp.auth.dto.MemberPrincipal;
+import com.matp.auth.jwt.JwtTokenProvider;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.server.DefaultServerRedirectStrategy;
+import org.springframework.security.web.server.ServerRedirectStrategy;
+import org.springframework.security.web.server.WebFilterExchange;
+import org.springframework.security.web.server.authentication.ServerAuthenticationSuccessHandler;
+import org.springframework.security.web.server.savedrequest.ServerRequestCache;
+import org.springframework.security.web.server.savedrequest.WebSessionServerRequestCache;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.util.UriComponentsBuilder;
+import reactor.core.publisher.Mono;
+
+import java.net.URI;
+import java.util.Date;
+
+
+/**
+ * 로그인 성공시 호출되며 jwt 생성 후 지정된 경로로 리다이렉트
+ */
+@Slf4j
+public class OAuthSuccessHandler implements ServerAuthenticationSuccessHandler {
+    private URI location = URI.create("/");
+    private final ServerRequestCache requestCache = new WebSessionServerRequestCache();
+    private final ServerRedirectStrategy redirectStrategy = new DefaultServerRedirectStrategy();
+    private JwtTokenProvider jwtTokenProvider;
+
+    public OAuthSuccessHandler(JwtTokenProvider jwtTokenProvider) {
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+    /**
+     * ReactiveOAuth2UserService에서 반환한 MemberPrincipal객체를 통해 jwt를 발급한다
+     */
+    @Override
+    public Mono<Void> onAuthenticationSuccess(WebFilterExchange webFilterExchange, Authentication authentication) {
+        MemberPrincipal principal = (MemberPrincipal) authentication.getPrincipal();
+
+        String accessToken = delegateAccessToken(principal);
+        String refreshToken = delegateRefreshToken(principal);
+
+        log.info("accessToken: {}", accessToken);
+        log.info("refreshToken: {}", refreshToken);
+
+        location = createUri(accessToken, refreshToken);
+
+        ServerWebExchange exchange = webFilterExchange.getExchange();
+        return this.requestCache.getRedirectUri(exchange).defaultIfEmpty(this.location)
+                .flatMap((location) -> this.redirectStrategy.sendRedirect(exchange, location));
+    }
+
+    private String delegateAccessToken(MemberPrincipal principal) {
+        Date expiration = jwtTokenProvider.getTokenExpiration(jwtTokenProvider.getAccessTokenExpirationMinutes());
+        return jwtTokenProvider.createAccessToken(principal, expiration);
+    }
+
+    private String delegateRefreshToken(MemberPrincipal principal) {
+        Date expiration = jwtTokenProvider.getTokenExpiration(jwtTokenProvider.getRefreshTokenExpirationMinutes());
+        return jwtTokenProvider.createRefreshToken(principal, expiration);
+    }
+
+    private URI createUri(String accessToken, String refreshToken) {
+        MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
+        queryParams.add("access_token", accessToken);
+        queryParams.add("refresh_token", refreshToken);
+
+        return UriComponentsBuilder
+                .newInstance()
+                .scheme("http")
+                .host("localhost")
+                .path("/token")
+                .queryParams(queryParams)
+                .build()
+                .toUri();
+    }
+
+}

--- a/server/matp/src/main/java/com/matp/auth/jwt/JwtAuthenticationFilter.java
+++ b/server/matp/src/main/java/com/matp/auth/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,51 @@
+package com.matp.auth.jwt;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.ReactiveSecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebFilter;
+import org.springframework.web.server.WebFilterChain;
+import reactor.core.publisher.Mono;
+
+
+/**
+ * reactive필터인 WebFilter의 구현체인 JwtAuthenticationFilter 작성
+ * 헤더에 포함된 jwt를 검증하는 필터
+ * 검증에 성공하면 해당 authentication을 ReactiveSecurityContextHolder에 담아서 다음 필터 체인에 넘긴다
+ */
+@Slf4j
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter implements WebFilter {
+    public static final String HEADER_PREFIX = "Bearer ";
+    private final JwtTokenProvider provider;
+
+    @NotNull
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
+        log.info("This is filter in JwtAuthenticationFilter!!!!");
+
+        String token = resolveToken(exchange.getRequest());
+        log.info("Token: {}", token);
+
+        if (StringUtils.hasText(token) && provider.validateToken(token)) {
+            log.info("Authentication Success!!");
+            Authentication authentication = provider.getAuthentication(token);
+            return chain.filter(exchange).contextWrite(ReactiveSecurityContextHolder.withAuthentication(authentication));
+        }
+        return chain.filter(exchange);
+    }
+
+    private String resolveToken(ServerHttpRequest request) {
+        String bearerToken = request.getHeaders().getFirst(HttpHeaders.AUTHORIZATION);
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(HEADER_PREFIX))
+            return bearerToken.substring(7);
+        return null;
+    }
+
+}

--- a/server/matp/src/main/java/com/matp/auth/jwt/JwtTokenProvider.java
+++ b/server/matp/src/main/java/com/matp/auth/jwt/JwtTokenProvider.java
@@ -1,0 +1,114 @@
+package com.matp.auth.jwt;
+
+import com.matp.auth.dto.MemberPrincipal;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Calendar;
+import java.util.Collection;
+import java.util.Date;
+
+
+/**
+ * jwt를 생성하는 프로바이더
+ * 인증에 성공하면 액세스 토큰과 리프레쉬 토큰을 생성한다
+ */
+@Slf4j
+@Component
+public class JwtTokenProvider {
+    @Getter
+    @Value("${jwt.key.secret}") private String jwtSecretKey;
+    @Getter @Value("${jwt.access-token-expiration-minutes}") private int accessTokenExpirationMinutes;
+    @Getter @Value("${jwt.refresh-token-expiration-minutes}") private int refreshTokenExpirationMinutes;
+    private SecretKey secretKey;
+    private static final String AUTHORITIES_KEY = "roles";
+
+    @PostConstruct
+    protected void init() {
+        String secret = Base64.getEncoder().encodeToString(jwtSecretKey.getBytes(StandardCharsets.UTF_8));
+        secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+    }
+
+    public String createAccessToken(MemberPrincipal principal, Date expiration) {
+        Claims claims = Jwts.claims().setSubject(principal.email());
+        claims.put(
+                AUTHORITIES_KEY,
+                principal.getAuthorities()
+        );
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(Calendar.getInstance().getTime())
+                .setExpiration(expiration)
+                .signWith(secretKey, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public String createRefreshToken(MemberPrincipal principal, Date expiration) {
+        return Jwts.builder()
+                .setSubject(principal.email())
+                .setIssuedAt(Calendar.getInstance().getTime())
+                .setExpiration(expiration)
+                .signWith(secretKey, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public String getUserEmail(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(secretKey)
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .getSubject();
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jws<Claims> claims = Jwts.parserBuilder()
+                    .setSigningKey(secretKey)
+                    .build()
+                    .parseClaimsJws(token);
+            if (claims.getBody().getExpiration().before(Calendar.getInstance().getTime()))
+                return false;
+            return true;
+        } catch (JwtException | IllegalArgumentException exception) {
+            log.warn("Invalid JWT token");
+            log.trace("Invalid JWT token trace", exception);
+        }
+        return false;
+    }
+
+    public Authentication getAuthentication(String token) {
+        Claims claims = Jwts.parserBuilder()
+                .setSigningKey(secretKey)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+
+        Collection<? extends GrantedAuthority> authorities = AuthorityUtils.commaSeparatedStringToAuthorityList(
+                claims.get(AUTHORITIES_KEY).toString());
+
+        MemberPrincipal principal = MemberPrincipal.of(claims.getSubject(), authorities); // TODO: 리팩토링 여지 있음
+
+        return new UsernamePasswordAuthenticationToken(principal, token, authorities);
+    }
+
+    public Date getTokenExpiration(int expirationMinutes) {
+        Calendar calendar = Calendar.getInstance();
+        calendar.add(Calendar.MINUTE, expirationMinutes);
+        return calendar.getTime();
+    }
+
+}

--- a/server/matp/src/main/java/com/matp/follow/controller/FollowController.java
+++ b/server/matp/src/main/java/com/matp/follow/controller/FollowController.java
@@ -1,0 +1,63 @@
+package com.matp.follow.controller;
+
+import com.matp.auth.jwt.JwtTokenProvider;
+import com.matp.follow.dto.FollowResponseWithInfo;
+import com.matp.follow.service.FollowService;
+import com.matp.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+
+/**
+ * 팔로우 등록, 팔로우 취소, 팔로잉 목록보기, 팔로워 목록보기 기능 담당 컨트롤러
+ */
+@RestController
+@RequestMapping("/members")
+@RequiredArgsConstructor
+public class FollowController {
+    private final FollowService followService;
+    private final MemberService memberService;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @PostMapping("/followings/{member-id}")
+    public Mono<ResponseEntity> followMember(@PathVariable("member-id") Long id,
+                                             ServerHttpRequest request) {
+        String email = extractEmail(request);
+        return memberService.postFollow(email, id).map(ResponseEntity::ok);
+    }
+
+    @DeleteMapping("/followings/{member-id}")
+    public Mono<ResponseEntity> followCancel(@PathVariable("member-id") Long id,
+                                             ServerHttpRequest request) {
+        String email = extractEmail(request);
+        return memberService.cancelFollow(email, id).map(ResponseEntity::ok);
+    }
+
+    @GetMapping("/followings")
+    public Flux<FollowResponseWithInfo> checkFollowings(ServerHttpRequest request) {
+        String email = extractEmail(request);
+        return followService.findFollowingByFollowerEmail(email);
+    }
+
+    @GetMapping("/followers")
+    public Flux<FollowResponseWithInfo> checkFollowers(ServerHttpRequest request) {
+        String email = extractEmail(request);
+        return followService.findFollowerByFollowingEmail(email);
+    }
+
+    /**
+     * 리퀘스트 헤더에 있는 토큰을 사용하여 이메일 추출
+     */
+    private String extractEmail(ServerHttpRequest request) {
+        String bearerToken = request.getHeaders().getFirst(HttpHeaders.AUTHORIZATION);
+        assert bearerToken != null;
+        bearerToken = bearerToken.substring(7);
+        return jwtTokenProvider.getUserEmail(bearerToken);
+    }
+
+}

--- a/server/matp/src/main/java/com/matp/follow/dto/FollowResponseWithInfo.java
+++ b/server/matp/src/main/java/com/matp/follow/dto/FollowResponseWithInfo.java
@@ -1,0 +1,20 @@
+package com.matp.follow.dto;
+
+import com.matp.member.dto.MemberDto;
+
+/**
+ * 팔로잉, 팔로워 목록보기 호출시 반환값 DTO - 닉네임, 프로필 URL
+ */
+public record FollowResponseWithInfo(
+        String nickname,
+        String profileUrl
+) {
+    public static FollowResponseWithInfo of(String nickname, String profileUrl) {
+        return new FollowResponseWithInfo(nickname, profileUrl);
+    }
+
+    public static FollowResponseWithInfo from(MemberDto dto) {
+        return new FollowResponseWithInfo(dto.nickname(), dto.profileUrl());
+    }
+
+}

--- a/server/matp/src/main/java/com/matp/follow/entity/Follow.java
+++ b/server/matp/src/main/java/com/matp/follow/entity/Follow.java
@@ -1,0 +1,40 @@
+package com.matp.follow.entity;
+
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.relational.core.mapping.Table;
+
+import java.time.LocalDateTime;
+
+
+@Builder
+@Getter
+@ToString
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Table
+public class Follow {
+    @Id private Long id;
+
+    @Setter private String followerEmail;
+
+    @Setter private String followingEmail;
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime modifiedAt;
+
+    private Follow(String followerEmail, String followingEmail) {
+        this.followerEmail = followerEmail;
+        this.followingEmail = followingEmail;
+    }
+
+    public static Follow of(String followerEmail, String followingEmail) {
+        return new Follow(followerEmail, followingEmail);
+    }
+
+}

--- a/server/matp/src/main/java/com/matp/follow/repository/FollowRepository.java
+++ b/server/matp/src/main/java/com/matp/follow/repository/FollowRepository.java
@@ -1,0 +1,26 @@
+package com.matp.follow.repository;
+
+import com.matp.follow.entity.Follow;
+import org.springframework.data.r2dbc.repository.Query;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+public interface FollowRepository extends ReactiveCrudRepository<Follow, Long> {
+    Mono<Follow> findByFollowerEmailAndFollowingEmail(String followerEmail, String followingEmail);
+    Mono<Void> deleteByFollowerEmailAndFollowingEmail(String followerEmail, String followingEmail);
+
+    Flux<Follow> findAllByFollowerEmail(String followerEmail);
+
+    Flux<Follow> findAllByFollowingEmail(String followingEmail);
+
+    @Query("select count(following_email) from follow where follower_email = :followerEmail")
+    Mono<Long> countAllByFollowingEmail(String followerEmail);
+
+    @Query("select count(follower_email) from follow where following_email = :followingEmail")
+    Mono<Long> countAllByFollowerEmail(String followingEmail);
+
+    @Query("select count(following_email), count(follower_email) from follow where following_email =: memberEmail or follower_email =: memberEmail")
+    Flux<Long> countAllByMemberEmail(String memberEmail);
+
+}

--- a/server/matp/src/main/java/com/matp/follow/service/FollowService.java
+++ b/server/matp/src/main/java/com/matp/follow/service/FollowService.java
@@ -1,0 +1,55 @@
+package com.matp.follow.service;
+
+import com.matp.follow.dto.FollowResponseWithInfo;
+import com.matp.follow.entity.Follow;
+import com.matp.follow.repository.FollowRepository;
+import com.matp.member.dto.MemberDto;
+import com.matp.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FollowService {
+    private final FollowRepository followRepository;
+    private final MemberRepository memberRepository;
+
+    /**
+     * 팔로우 등록이 중복되어 저장되면 안되므로 데이터베이스에 확인후 저장
+     */
+    public Mono<Void> post(String followerEmail, String followingEmail) {
+        return followRepository.findByFollowerEmailAndFollowingEmail(followerEmail, followingEmail)
+                .switchIfEmpty(followRepository.save(Follow.of(followerEmail, followingEmail)))
+                .then();
+    }
+
+    public Mono<Void> cancel(String followerEmail, String followingEmail) {
+        return followRepository.deleteByFollowerEmailAndFollowingEmail(followerEmail, followingEmail);
+    }
+
+    /**
+     * 팔로워 이메일로 팔로잉 목록 불러오기
+     */
+    public Flux<FollowResponseWithInfo> findFollowingByFollowerEmail(String followerEmail) {
+        return followRepository.findAllByFollowerEmail(followerEmail)
+                .flatMap(follow -> memberRepository.findByEmail(follow.getFollowingEmail()))
+                .map(MemberDto::from)
+                .map(FollowResponseWithInfo::from);
+    }
+
+    /**
+     * 팔로잉 이메일로 팔로워 목록 불러오기
+     */
+    public Flux<FollowResponseWithInfo> findFollowerByFollowingEmail(String followingEmail) {
+        return followRepository.findAllByFollowingEmail(followingEmail)
+                .flatMap(follow -> memberRepository.findByEmail(follow.getFollowerEmail()))
+                .map(MemberDto::from)
+                .map(FollowResponseWithInfo::from);
+    }
+
+}

--- a/server/matp/src/main/java/com/matp/member/controller/MemberController.java
+++ b/server/matp/src/main/java/com/matp/member/controller/MemberController.java
@@ -1,0 +1,90 @@
+package com.matp.member.controller;
+
+import com.matp.auth.jwt.JwtTokenProvider;
+import com.matp.member.dto.MemberPatchDto;
+import com.matp.member.dto.MemberResponse;
+import com.matp.member.dto.MemberSearchResponse;
+import com.matp.member.repository.MemberRepository;
+import com.matp.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.Map;
+
+
+/**
+ * 마이페이지, memberId로 조회, 닉네임으로 검색, 회원 정보 수정 기능 담당 컨트롤러
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/members")
+public class MemberController {
+    private final MemberRepository memberRepository; // 기능 확인 위해 임시로 추가
+    private final MemberService memberService;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    /**
+     * 유저 정보와 팔로우 정보를 함께 가져온 후 토큰에서 email 추출하여 해당 유저 정보만 반환
+     * TODO: pickerList도 함께 가져와야 함
+     */
+    @GetMapping("/mypage")
+    public Mono<ResponseEntity<MemberResponse>> myPage(ServerHttpRequest request) {
+        String email = extractEmail(request);
+        return memberService.findAllWithInfo()
+                .filter(member -> member.email().equals(email))
+                .last()
+                .map(ResponseEntity::ok);
+    }
+
+    /**
+     * 유저 정보와 팔로우 정보를 함께 가져온 후 memberId로 해당 유저 정보만 반환
+     * TODO: pickerList도 함께 가져와야 함
+     */
+    @GetMapping("/{member-id}")
+    public Mono<ResponseEntity<MemberResponse>> findMember(@PathVariable("member-id") Long id) {
+        return memberService.findAllWithInfo()
+                .filter(member -> member.id().equals(id))
+                .last()
+                .map(ResponseEntity::ok);
+    }
+
+    @GetMapping
+    public Flux<MemberSearchResponse> findMembers(@RequestBody Map<String, String> nicknameMap) {
+        return memberService.findAllWithInfo()
+                .filter(member -> member.nickname().equals(nicknameMap.get("nickname")))
+                .map(MemberSearchResponse::from);
+    }
+
+    @PatchMapping
+    public Mono<ResponseEntity<MemberPatchDto>> updateMember(@RequestBody MemberPatchDto patchRequest,
+                                                             ServerHttpRequest request) {
+        String email = extractEmail(request);
+        return memberService.updateMember(email, patchRequest)
+                .map(MemberPatchDto::from)
+                .map(ResponseEntity::ok);
+    }
+
+    // 기능 확인 위해 임시로 추가
+    @DeleteMapping("/{member-id}")
+    public Mono<ResponseEntity<String>> deleteMember(@PathVariable("member-id") Long id) {
+        return memberRepository.deleteById(id)
+                .then(Mono.just(new ResponseEntity<>("삭제 완료", HttpStatus.NO_CONTENT)));
+    }
+
+    /**
+     * 리퀘스트 헤더에 있는 토큰을 사용하여 이메일 추출
+     */
+    private String extractEmail(ServerHttpRequest request) {
+        String bearerToken = request.getHeaders().getFirst(HttpHeaders.AUTHORIZATION);
+        assert bearerToken != null;
+        bearerToken = bearerToken.substring(7);
+        return jwtTokenProvider.getUserEmail(bearerToken);
+    }
+
+}

--- a/server/matp/src/main/java/com/matp/member/dto/MemberDto.java
+++ b/server/matp/src/main/java/com/matp/member/dto/MemberDto.java
@@ -1,0 +1,61 @@
+package com.matp.member.dto;
+
+import com.matp.member.entity.Member;
+
+import java.time.LocalDateTime;
+
+/**
+ * 회원 엔티티 정보를 담는 DTO
+ */
+public record MemberDto(
+        Long memberId,
+        String email,
+        String nickname,
+        String birthday,
+        String profileUrl,
+        Integer gender,
+        String memo,
+        String registrationId,
+        LocalDateTime createdAt,
+        LocalDateTime modifiedAt
+) {
+    public static MemberDto of(Long memberId, String email, String nickname, String birthday, String profileUrl, Integer gender, String memo, String registrationId, LocalDateTime createdAt, LocalDateTime modifiedAt) {
+        return new MemberDto(memberId, email, nickname, birthday, profileUrl, gender, memo, registrationId, createdAt, modifiedAt);
+    }
+
+    public static MemberDto of(String email, String nickname, String birthday, String profileUrl, Integer gender, String memo, String registrationId) {
+        return new MemberDto(null, email, nickname, birthday, profileUrl, gender, memo, registrationId, null, null);
+    }
+
+    public static MemberDto of(String email, String nickname, String profileUrl, String registrationId) {
+        return new MemberDto(null, email, nickname, null, profileUrl, null, null, registrationId, null, null);
+    }
+
+    public static MemberDto from(Member entity) {
+        return new MemberDto(
+                entity.getMemberId(),
+                entity.getEmail(),
+                entity.getNickname(),
+                entity.getBirthday(),
+                entity.getProfileUrl(),
+                entity.getGender(),
+                entity.getMemo(),
+                entity.getRegistrationId(),
+                entity.getCreatedAt(),
+                entity.getModifiedAt()
+        );
+    }
+
+    public Member toEntity() {
+        return Member.of(
+                email,
+                nickname,
+                birthday,
+                profileUrl,
+                gender,
+                memo,
+                registrationId
+        );
+    }
+
+}

--- a/server/matp/src/main/java/com/matp/member/dto/MemberPatchDto.java
+++ b/server/matp/src/main/java/com/matp/member/dto/MemberPatchDto.java
@@ -1,0 +1,23 @@
+package com.matp.member.dto;
+
+/**
+ * 회원 정보 수정 시 사용되는 DTO
+ */
+public record MemberPatchDto(
+        String nickname,
+        String profileUrl,
+        String memo
+) {
+    public static MemberPatchDto of(String nickname, String profileUrl, String memo) {
+        return new MemberPatchDto(nickname, profileUrl, memo);
+    }
+
+    public static MemberPatchDto from(MemberResponse response) {
+        return new MemberPatchDto(
+                response.nickname(),
+                response.profileUrl(),
+                response.memo()
+        );
+    }
+
+}

--- a/server/matp/src/main/java/com/matp/member/dto/MemberResponse.java
+++ b/server/matp/src/main/java/com/matp/member/dto/MemberResponse.java
@@ -1,0 +1,54 @@
+package com.matp.member.dto;
+
+import com.matp.member.entity.Member;
+import com.matp.post.dto.SimplePostResponse;
+
+import java.util.List;
+
+/**
+ * 팔로우 정보를 포함하는 반환 DTO
+ * TODO: 피커정보도 포함되어야 함
+ */
+public record MemberResponse(
+        Long id,
+        String email,
+        String nickname,
+        String birthday,
+        String profileUrl,
+        Integer gender,
+        String memo,
+        Long followers,
+        Long followings,
+        List<SimplePostResponse> postInfos
+) {
+    public static MemberResponse from(MemberDto dto) {
+        return new MemberResponse(
+                dto.memberId(),
+                dto.email(),
+                dto.nickname(),
+                dto.birthday(),
+                dto.profileUrl(),
+                dto.gender(),
+                dto.memo(),
+                null,
+                null,
+                null
+        );
+    }
+
+    public static MemberResponse from(Member entity) {
+        return new MemberResponse(
+                entity.getMemberId(),
+                entity.getEmail(),
+                entity.getNickname(),
+                entity.getBirthday(),
+                entity.getProfileUrl(),
+                entity.getGender(),
+                entity.getMemo(),
+                entity.getFollowers(),
+                entity.getFollowings(),
+                entity.getPostInfos()
+        );
+    }
+
+}

--- a/server/matp/src/main/java/com/matp/member/dto/MemberSearchResponse.java
+++ b/server/matp/src/main/java/com/matp/member/dto/MemberSearchResponse.java
@@ -1,0 +1,23 @@
+package com.matp.member.dto;
+
+/**
+ * 닉네임으로 회원 검색시 결과 반환 DTO
+ */
+public record MemberSearchResponse(
+        Long id,
+        String nickname,
+        String profileUrl,
+        String memo,
+        Long followers
+) {
+    public static MemberSearchResponse from(MemberResponse response) {
+        return new MemberSearchResponse(
+                response.id(),
+                response.nickname(),
+                response.profileUrl(),
+                response.memo(),
+                response.followers()
+        );
+    }
+
+}

--- a/server/matp/src/main/java/com/matp/member/entity/Member.java
+++ b/server/matp/src/main/java/com/matp/member/entity/Member.java
@@ -1,0 +1,72 @@
+package com.matp.member.entity;
+
+import com.matp.post.dto.SimplePostResponse;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.annotation.Transient;
+import org.springframework.data.relational.core.mapping.Table;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+
+@Builder
+@Getter
+@ToString
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Table
+public class Member {
+    @Id private Long memberId;
+
+    private String email;
+
+    @Setter private String nickname;
+
+    private String birthday;
+
+    @Setter private String profileUrl;
+
+    private Integer gender;
+
+    @Setter private String memo;
+
+    private String registrationId;
+
+    @CreatedDate private LocalDateTime createdAt;
+
+    @LastModifiedDate private LocalDateTime modifiedAt;
+
+    /**
+     * @Transient 어노테이션을 사용하여 테이블에 반영되지 않고 회원 조회 시 팔로잉, 팔로워 수를 같이 가져온다
+     * TODO: 피커 리스트도 함꼐 가져와야 함
+     */
+    @Transient private Long followings;
+    @Transient private Long followers;
+    @Transient private List<SimplePostResponse> postInfos;
+
+    private Member(String email, String nickname, String birthday, String profileUrl, Integer gender, String memo, String registrationId) {
+        this.email = email;
+        this.nickname = nickname;
+        this.birthday = birthday;
+        this.profileUrl = profileUrl;
+        this.gender = gender;
+        this.memo = memo;
+        this.registrationId = registrationId;
+    }
+
+    public static Member of(String email, String nickname, String birthday, String profileUrl, Integer gender, String memo, String registrationId) {
+        return new Member(email, nickname, birthday, profileUrl, gender, memo, registrationId);
+    }
+
+    public static Member of(String email, String nickname, String birthday, String profileUrl, Integer gender, String registrationId) {
+        return new Member(email, nickname, birthday, profileUrl, gender, null, registrationId);
+    }
+
+    public static Member of(String email, String nickname, String profileUrl, String registrationId) {
+        return new Member(email, nickname, null, profileUrl, null, null, registrationId);
+    }
+
+}

--- a/server/matp/src/main/java/com/matp/member/repository/MemberCustomRepository.java
+++ b/server/matp/src/main/java/com/matp/member/repository/MemberCustomRepository.java
@@ -1,0 +1,81 @@
+package com.matp.member.repository;
+
+import com.matp.member.dto.MemberResponse;
+import com.matp.member.entity.Member;
+import com.matp.post.dto.SimplePostResponse;
+import com.matp.post.entity.Post;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.r2dbc.core.DatabaseClient;
+import org.springframework.stereotype.Repository;
+import reactor.core.publisher.Flux;
+
+import java.time.LocalDateTime;
+import java.util.Comparator;
+
+/**
+ * DatabaseClient 사용하여 레포지토리 구현
+ * 직접 SQL 쿼리문을 작성하여 유저 정보를 조회할 때 팔로우 테이블도 조회하여 팔로잉과 팔로워 수를 카운트하여 가져온다
+ */
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class MemberCustomRepository {
+    private static final String MEMBER_ID_FIELD_NAME = "memberId";
+    private final DatabaseClient databaseClient;
+
+    /**
+     * 회원 정보를 조회하여 MemberResponse로 매핑 후 가져올 때
+     * 팔로우 카운팅과 팔로워 카운팅, 포스트 정보들도 함꼐 조회하여 가져온다
+     */
+    public Flux<MemberResponse> findWithFollow() {
+        var sqlWithFollow = """
+                SELECT 
+                    m.member_id as memberId, m.email as email, m.nickname as nickname,
+                    m.birthday as birthday, m.profile_url as profileUrl, 
+                    m.gender as gender, m.memo as memo, m.registration_id as registrationId,
+                    m.created_at as createdAt, m.modified_at as modifiedAt,
+                    p.id as postId, p.title as title, p.thumbnail_url as thumbnailUrl,
+                    (SELECT COUNT(f.follower_email) as followers FROM follow f WHERE m.email = f.following_email),
+                    (SELECT COUNT(f.following_email) as followings FROM follow f WHERE m.email = f.follower_email)   
+                FROM member m
+                INNER JOIN post p
+                ON m.member_id = p.member_id
+                """;
+
+        return databaseClient.sql(sqlWithFollow)
+                .fetch().all()
+                .sort(Comparator.comparing(result -> (Long) result.get(MEMBER_ID_FIELD_NAME)))
+                .bufferUntilChanged(result -> result.get(MEMBER_ID_FIELD_NAME))
+                .map(result -> {
+                    var followers = Long.parseLong(result.get(0).get("(SELECT COUNT(f.follower_email) as followers FROM follow f WHERE m.email = f.following_email)").toString());
+                    var followings = Long.parseLong(result.get(0).get("(SELECT COUNT(f.following_email) as followings FROM follow f WHERE m.email = f.follower_email)").toString());
+
+                    var postInfos = result.stream()
+                            .map(row -> SimplePostResponse.builder()
+                                    .postId((Long) row.get("postId"))
+                                    .title((String) row.get("title"))
+                                    .thumbnailUrl((String) row.get("thumbnailUrl"))
+                                    .build())
+                            .toList();
+
+                    var row = result.get(0);
+                    return MemberResponse.from(Member.builder()
+                            .memberId((Long) row.get(MEMBER_ID_FIELD_NAME))
+                            .email((String) row.get("email"))
+                            .nickname((String) row.get("nickname"))
+                            .birthday((String) row.get("birthday"))
+                            .profileUrl((String) row.get("profileUrl"))
+                            .gender((Integer) row.get("gender"))
+                            .memo((String) row.get("memo"))
+                            .registrationId((String) row.get("registrationId"))
+                            .createdAt((LocalDateTime) row.get("createdAt"))
+                            .modifiedAt((LocalDateTime) row.get("modifiedAt"))
+                            .followings(followings)
+                            .followers(followers)
+                            .postInfos(postInfos)
+                            .build());
+                });
+    }
+
+}

--- a/server/matp/src/main/java/com/matp/member/repository/MemberRepository.java
+++ b/server/matp/src/main/java/com/matp/member/repository/MemberRepository.java
@@ -1,0 +1,19 @@
+package com.matp.member.repository;
+
+import com.matp.member.entity.Member;
+import org.springframework.data.r2dbc.repository.Query;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+public interface MemberRepository extends ReactiveCrudRepository<Member, Long> {
+    Mono<Member> findByEmail(String email);
+
+    Flux<Member> findAllByNickname(String nickname);
+
+    Mono<Member> findByMemberId(Long memberId);
+
+    @Query("SELECT count(member_id) FROM member")
+    Mono<Long> findMemberCount();
+
+}

--- a/server/matp/src/main/java/com/matp/member/service/MemberService.java
+++ b/server/matp/src/main/java/com/matp/member/service/MemberService.java
@@ -1,0 +1,138 @@
+package com.matp.member.service;
+
+import com.matp.follow.dto.FollowResponseWithInfo;
+import com.matp.follow.service.FollowService;
+import com.matp.member.dto.MemberDto;
+import com.matp.member.dto.MemberPatchDto;
+import com.matp.member.dto.MemberResponse;
+import com.matp.member.entity.Member;
+import com.matp.member.repository.MemberCustomRepository;
+import com.matp.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+    private final MemberRepository memberRepository;
+    private final FollowService followService;
+    private final MemberCustomRepository memberCustomRepository;
+
+    @Transactional(readOnly = true)
+    public Flux<MemberResponse> findAllWithInfo() {
+        return memberCustomRepository.findWithFollow();
+    }
+
+    @Transactional(readOnly = true)
+    public Mono<MemberDto> findMemberById(Long memberId) {
+        return memberRepository.findById(memberId)
+                .map(MemberDto::from);
+    }
+
+    @Transactional(readOnly = true)
+    public Mono<MemberDto> findMemberByEmail(String email) {
+        return memberRepository.findByEmail(email)
+                .map(MemberDto::from);
+    }
+
+    @Transactional(readOnly = true)
+    public Mono<MemberDto> findMember(String email) {
+        return memberRepository.findByEmail(email)
+                .map(MemberDto::from);
+    }
+
+    @Transactional(readOnly = true)
+    public Flux<MemberResponse> findMembers(String nickname) {
+        return memberRepository.findAllByNickname(nickname)
+                .map(MemberDto::from)
+                .map(MemberResponse::from);
+    }
+
+    @Transactional
+    public Mono<MemberDto> saveMember(String email, String nickname, String birthday, String profileUrl, Integer gender, String registrationId) {
+        log.info("This is saveMember in MemberService!!!!");
+
+        Member member = Member.of(email, nickname, birthday, profileUrl, gender, registrationId);
+        Mono<Member> savedMember = memberRepository.save(member);
+
+        return savedMember.map(MemberDto::from);
+    }
+
+    @Transactional
+    public Mono<MemberDto> saveMember(MemberDto dto) {
+        Member member = dto.toEntity();
+        return memberRepository.save(member)
+                .map(MemberDto::from);
+    }
+
+    @Transactional
+    public Mono<MemberResponse> updateMember(String email, MemberPatchDto request) {
+        return memberRepository.findByEmail(email)
+                .flatMap(member -> {
+                    if (request.nickname() != null) member.setNickname(request.nickname());
+                    if (request.profileUrl() != null) member.setProfileUrl(request.profileUrl());
+                    if (request.memo() != null) member.setMemo(request.memo());
+
+                    return memberRepository.save(member);
+                })
+                .map(MemberDto::from)
+                .map(MemberResponse::from);
+    }
+
+    @Transactional
+    public Mono<Void> postFollow(String email, Long followingId) {
+        return getMemberEmail(followingId)
+                .flatMap(followingEmail -> {
+                    return followService.post(email, followingEmail);
+                });
+    }
+
+    @Transactional
+    public Mono<Void> cancelFollow(String email, Long followingId) {
+        return getMemberEmail(followingId)
+                .flatMap(followingEmail -> {
+                    return followService.cancel(email, followingEmail);
+                });
+    }
+
+    public Flux<FollowResponseWithInfo> checkFollowing(String email) {
+        return followService.findFollowingByFollowerEmail(email);
+    }
+
+    public Flux<FollowResponseWithInfo> checkFollower(String email) {
+        return followService.findFollowerByFollowingEmail(email);
+    }
+
+    @Transactional(readOnly = true)
+    public Mono<Void> verifyExistEmail(String email) {
+        return memberRepository.findByEmail(email)
+                .flatMap(findMember -> {
+                    if (findMember != null) {
+                        return Mono.error(new IllegalArgumentException("해당 유저가 존재함"));
+                    }
+                    return Mono.empty();
+                });
+    }
+
+    @Transactional(readOnly = true)
+    public Mono<Void> verifyExistId(Long memberId) {
+        return memberRepository.findById(memberId)
+                .switchIfEmpty(Mono.error(new IllegalArgumentException("해당 유저가 존재하지 않음")))
+                .then();
+    }
+
+    private Mono<Long> getMemberId(String email) {
+        return memberRepository.findByEmail(email).map(Member::getMemberId);
+    }
+
+    private Mono<String> getMemberEmail(Long id) {
+        return memberRepository.findById(id).map(Member::getEmail);
+    }
+
+}

--- a/server/matp/src/main/java/com/matp/post/dto/SimplePostResponse.java
+++ b/server/matp/src/main/java/com/matp/post/dto/SimplePostResponse.java
@@ -1,0 +1,13 @@
+package com.matp.post.dto;
+
+import com.matp.post.entity.Post;
+import lombok.Builder;
+
+@Builder
+public record SimplePostResponse(
+        Long postId,
+        String title,
+        String thumbnailUrl
+) {
+
+}


### PR DESCRIPTION
## What is this PR?(작업 내용) :mag:
- Webflux를 사용하여 리액티브하게 구성
- OAuth2를 사용한 소셜 로그인
- 로그인 성공 시 JWT 발급
- 유저 관련 기능 작성
  - 마이페이지 조회 
  - ID값으로 해당 유저 조회 기능
  - 닉네임 검색 
  - 회원 정보 수정 
- 팔로우 관련 기능 작성
  - 팔로우 등록 
  - 팔로우 취소
  - 팔로잉 목록 조회
  - 팔로워 목록 조회

## review point :memo:
- 팔로우 테이블을 회원ID 값에서 회원 이메일로 변경 
  - 토큰 검증시 이메일을 사용하기 때문에 ID값으로 팔로우 테이블을 만들면 유저 이메일로 한번 더 유저를 조회하여 ID값을 
가져와야 하므로 불필요한 조회 과정이 추가됨 
- 'MemberCustomRepository'에 대한 리팩토링이 필요해 보임

## Background(문제 배경) 🖼️ 
- JPA는 시큐리티 필터 체인을 구성할 때 HttpSecurity를 사용하여 구현하는데 이때 oauth2Login이라는 메소드에 체이닝으로 userInfoEndpoint라는 함수가 있어서 OAuth2UserService를 구현한 후 넣어주면 됐었는데 webflux에서는 ServerHttpSecurity 를 사용합니다. HttpSecurity와 ServerHttpSecurity 는 구조가 좀 달라서 ReactiveOAuth2UserService의 반환 값을 어떻게 가져와야 하나 고민이 많이 되었는데 디버깅을 해보니 빈으로 등록되어 핸들러에서 authentication 객체로 가져올 수 있었습니다 


## important(같이 논의할 내용) ❓ 
- MemberCustomRepository의 findWithFollow 메서드의 효율성 논의 필요
