### PR TITLE
맛포스트 모달 useAxios 실시간 업데이트 관련 수정 사항 PR입니다.

### DIFF
--- a/client/src/components/MatPostModal/MatCommentAdd.tsx
+++ b/client/src/components/MatPostModal/MatCommentAdd.tsx
@@ -51,7 +51,7 @@ const MatCommentAdd = ({
         comment,
         createdAt
       ),
-    [comment, createdAt],
+    [comment],
     true
   );
 

--- a/client/src/components/MatPostModal/MatPostUpdate.tsx
+++ b/client/src/components/MatPostModal/MatPostUpdate.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable */
+
 import { useParams } from "react-router";
 import styled from "styled-components";
 import { useEffect, useState } from "react";
@@ -129,7 +130,6 @@ const StyledStar = styled.div`
   }
 `;
 
-
 const PostUpdateModal = ({}: // closeModalHandler,
 {
   // closeModalHandler?: React.MouseEventHandler;
@@ -169,7 +169,7 @@ const PostUpdateModal = ({}: // closeModalHandler,
         thumbnailUrl,
         Number(id)
       ),
-    [newTitle, htmlContent, createdAt, clicked, thumbnailUrl],
+    [newTitle, htmlContent, clicked, thumbnailUrl],
     true
   );
 


### PR DESCRIPTION
## What is this PR?(작업 내용) :mag:
- 맛 포스트 수정 및 댓글 추가 기능(MatPostUpdate, MatComment)의 useAxios 종속성 배열(deps)에서 createdAt 변수가 제외되도록 수정하였습니다. 

## review point :memo:
- 기능이 정상 작동되는지 확인 부탁드리겠습니다. 

## Background(문제 배경) 🖼️ 
- 맛 포스트 수정 및 댓글 추가 시 실시간 업데이트되는 기능을 수정/보완하였습니다.

## important(같이 논의할 내용) ❓ 
- review point와 상동!
