### PR TITLE
피커 리팩토링

### DIFF
--- a/server/matp/src/main/java/com/matp/picker/controller/PickerController.java
+++ b/server/matp/src/main/java/com/matp/picker/controller/PickerController.java
@@ -1,27 +1,41 @@
 package com.matp.picker.controller;
 
+import com.matp.picker.dto.PickerRequestDto;
 import com.matp.picker.dto.PickerResponseDto;
 import com.matp.picker.service.PickerService;
+import com.matp.place.dto.PlaceResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 @RestController
-@RequestMapping("/places/{place-id}/pickers")
+@RequestMapping("/pickers")
 @RequiredArgsConstructor
 public class PickerController {
     private final PickerService pickerService;
 
-    @PostMapping("/{group-id}")
-    public Mono<ResponseEntity<PickerResponseDto>> pickPlace(@PathVariable("place-id") long placeId, @PathVariable("group-id") long groupId) {
-        return pickerService.pickPlace(placeId, groupId, 1L)
+    @PostMapping
+    public Mono<ResponseEntity<PickerResponseDto>> pickPlace(@RequestBody PickerRequestDto pickerRequestDto) {
+        return pickerService.pickPlace(pickerRequestDto.placeId(), pickerRequestDto.pickerGroupId(), 4L)
                 .map(response -> new ResponseEntity<>(response, HttpStatus.CREATED));
     }
 
-    @DeleteMapping
+    @PatchMapping
+    public Mono<ResponseEntity<PickerResponseDto>> updatePickPlace(@RequestBody PickerRequestDto pickerRequestDto) {
+        return pickerService.updatePickPlace(pickerRequestDto.placeId(), pickerRequestDto.pickerGroupId(), 4L)
+                .map(response -> new ResponseEntity<>(response, HttpStatus.OK));
+    }
+
+    @DeleteMapping("/{place-id}")
     public Mono<Void> cancelPickPlace(@PathVariable("place-id") long placeId) {
-        return pickerService.cancelPickPlace(placeId, 1L);
+        return pickerService.cancelPickPlace(placeId, 4L);
+    }
+
+    @GetMapping("/{group-id}")
+    public Flux<PlaceResponseDto> findPickPlaces(@PathVariable("group-id") long groupId) {
+        return pickerService.findPickersByGroup(groupId, 4L);
     }
 }

--- a/server/matp/src/main/java/com/matp/picker/dto/PickerRequestDto.java
+++ b/server/matp/src/main/java/com/matp/picker/dto/PickerRequestDto.java
@@ -1,0 +1,4 @@
+package com.matp.picker.dto;
+
+public record PickerRequestDto(Long placeId, Long pickerGroupId) {
+}

--- a/server/matp/src/main/java/com/matp/picker/dto/PickerResponseDto.java
+++ b/server/matp/src/main/java/com/matp/picker/dto/PickerResponseDto.java
@@ -4,12 +4,12 @@ import com.matp.picker.entity.Picker;
 import lombok.Builder;
 
 @Builder
-public record PickerResponseDto(Long id, Long placeId, Long groupId, Long memberId) {
+public record PickerResponseDto(Long id, Long placeId, Long pickerGroupId, Long memberId) {
     public static PickerResponseDto of(Picker picker) {
         return PickerResponseDto.builder()
                 .id(picker.getId())
                 .placeId(picker.getPlaceId())
-                .groupId(picker.getGroupId())
+                .pickerGroupId(picker.getPickerGroupId())
                 .memberId(picker.getMemberId())
                 .build();
     }

--- a/server/matp/src/main/java/com/matp/picker/entity/Picker.java
+++ b/server/matp/src/main/java/com/matp/picker/entity/Picker.java
@@ -18,7 +18,7 @@ public class Picker {
 
     private Long placeId;
 
-    private Long groupId;
+    private Long pickerGroupId;
 
     private Long memberId;
 
@@ -28,13 +28,11 @@ public class Picker {
     @LastModifiedDate
     private LocalDateTime modifiedAt;
 
-    public static Picker of(Long placeId, Long groupId, Long memberId) {
+    public static Picker of(Long placeId, Long pickerGroupId, Long memberId) {
         return Picker.builder()
                 .placeId(placeId)
-                .groupId(groupId)
+                .pickerGroupId(pickerGroupId)
                 .memberId(memberId)
-                .createdAt(LocalDateTime.now())
-                .modifiedAt(LocalDateTime.now())
                 .build();
     }
 }

--- a/server/matp/src/main/java/com/matp/picker/repository/PickerRepository.java
+++ b/server/matp/src/main/java/com/matp/picker/repository/PickerRepository.java
@@ -9,7 +9,7 @@ import reactor.core.publisher.Mono;
 public interface PickerRepository extends ReactiveCrudRepository<Picker, Long> {
 
     @Query("""
-    SELECT id, place_id, group_id, member_id
+    SELECT *
     FROM picker 
     WHERE place_id = :placeId and member_id = :memberId;
     """)
@@ -23,4 +23,6 @@ public interface PickerRepository extends ReactiveCrudRepository<Picker, Long> {
     Mono<Void> deleteByIds(long placeId, long memberId);
 
     Flux<Picker> findByPlaceId(long placeId);
+
+    Flux<Picker> findByPickerGroupId(long pickerGroupId);
 }

--- a/server/matp/src/main/java/com/matp/place/dto/PlaceDetailResponseDto.java
+++ b/server/matp/src/main/java/com/matp/place/dto/PlaceDetailResponseDto.java
@@ -69,6 +69,7 @@ public record PlaceDetailResponseDto(Long id,
                 .name(place.getName())
                 .category(place.getCategory())
                 .isPick(isPick)
+                .groupImgIndex(4)
                 .longitude((Double) point[0])
                 .latitude((Double) point[1])
                 .posts(posts)

--- a/server/matp/src/main/java/com/matp/place/repository/PlaceRepository.java
+++ b/server/matp/src/main/java/com/matp/place/repository/PlaceRepository.java
@@ -7,9 +7,8 @@ import org.springframework.data.repository.reactive.ReactiveCrudRepository;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
-public interface PlaceRepositiory extends ReactiveCrudRepository<Place, Long> {
-    // SELECT에 추가되야할 내용 - img
-    // 쿼리에 추가되야할 내용 - 탑 15개
+public interface PlaceRepository extends ReactiveCrudRepository<Place, Long> {
+
 
     @Query("""
         SELECT id, tel, address, name, st_astext(point) as point
@@ -46,4 +45,11 @@ public interface PlaceRepositiory extends ReactiveCrudRepository<Place, Long> {
             values(:tel, :address, :roadNameAddress, :name, :category)
             """)
     Mono<PlaceEnrollmentResponse> registerPlaceInfo(String tel, String address, String roadNameAddress, String name, String category);
+
+    @Query("""
+        SELECT id, tel, address, name, st_astext(point) as point
+        FROM place
+        WHERE id = :placeId
+    """)
+    Flux<Place> findByPlaceId(long placeId);
 }


### PR DESCRIPTION
## What is this PR?(작업 내용) :mag:
- 피커 생성 및 삭제 앤드포인트 변경
- 피커 그룹 조회 및 수정 기능 추가
- 그룹 없을 경우 플레이스 조회시 나오는 groupImgIndex 기본값 0에서 4로 변경

## review point :memo:
- 
- 

## Background(문제 배경) 🖼️ 
- 플레이스 서비스에서 피커 서비스를 참조하고, 피커 서비스에서 플레이스 서비스를 참조하는 순환참조가 일어나서
플레이스 서비스에서 피커 레포지토리를 참조하는 방식으로 변경했습니다
- 피커 그룹에서 플레이스 조회시 flatMap을 사용하면 `There is a query still being run here - race -> false` 에러가 발생하여 concatMap을 사용하여 해결하였고, 상대적으로 조회 속도가 느려지는것 같습니다
근본적인 문제는 조인으로 해결하거나, 평점만 가져오기 때문에 좋아요처럼 평점을 포스트에서 따로 떼어내면 해결가능할 것 같습니다
에러해결에 참고한 페이지 https://github.com/jasync-sql/jasync-sql/issues/255


## important(같이 논의할 내용) ❓ 
- 
- 
