### PR TITLE
플레이스 조회 리팩토링

### DIFF
--- a/server/matp/src/main/java/com/matp/place/dto/PlaceDetailResponseDto.java
+++ b/server/matp/src/main/java/com/matp/place/dto/PlaceDetailResponseDto.java
@@ -19,6 +19,7 @@ public record PlaceDetailResponseDto(Long id,
                                      String category,
                                      double starAvg,
                                      int[] starCount,
+                                     String fiveStarProbability,
                                      int postCount,
                                      int pickCount,
                                      boolean isPick,
@@ -28,15 +29,16 @@ public record PlaceDetailResponseDto(Long id,
                                      double latitude,
                                      List<PlaceDetailPostDto> posts) {
     public static PlaceDetailResponseDto of(Place place, List<PlaceDetailPostDto> posts, List<Picker> pickers, boolean isPick, Group group) {
-        Object[] point = Arrays.stream(place.getPoint().substring(6,place.getPoint().length()-1).split(" ")).map(Double::parseDouble).toArray();
+        Object[] point = Arrays.stream(place.getPoint().substring(6, place.getPoint().length() - 1).split(" ")).map(Double::parseDouble).toArray();
         int[] starCount = new int[5];
-        posts.stream().forEach(post -> starCount[post.star()-1]++);
+        posts.stream().forEach(post -> starCount[post.star() - 1]++);
         return PlaceDetailResponseDto.builder()
                 .id(place.getId())
                 .tel(place.getTel())
-                .img(posts.get((int) (Math.random() * posts.size())).thumbnailUrl())
+                .img(!posts.isEmpty() ? posts.get((int) (Math.random() * posts.size())).thumbnailUrl() : null) // null 대신 기본이미지
                 .starAvg(posts.stream().map(PlaceDetailPostDto::star).collect(Collectors.averagingDouble(Integer::doubleValue)))
                 .starCount(starCount)
+                .fiveStarProbability(String.format("%.1f", ((double) (starCount[4] + 1) / (posts.size() + 5) * 100)))
                 .postCount(posts.size())
                 .pickCount(pickers.size())
                 .address(place.getAddress())
@@ -44,32 +46,8 @@ public record PlaceDetailResponseDto(Long id,
                 .name(place.getName())
                 .category(place.getCategory())
                 .isPick(isPick)
-                .groupName(group.getName())
-                .groupImgIndex(group.getGroupImgIndex())
-                .longitude((Double) point[0])
-                .latitude((Double) point[1])
-                .posts(posts)
-                .build();
-    }
-
-    public static PlaceDetailResponseDto of(Place place, List<PlaceDetailPostDto> posts, List<Picker> pickers, boolean isPick) {
-        Object[] point = Arrays.stream(place.getPoint().substring(6,place.getPoint().length()-1).split(" ")).map(Double::parseDouble).toArray();
-        int[] starCount = new int[5];
-        posts.stream().forEach(post -> starCount[post.star()-1]++);
-        return PlaceDetailResponseDto.builder()
-                .id(place.getId())
-                .tel(place.getTel())
-                .img(posts.size() > 0 ? posts.get((int) (Math.random() * posts.size())).thumbnailUrl() : null)
-                .starAvg(posts.stream().map(PlaceDetailPostDto::star).collect(Collectors.averagingDouble(Integer::doubleValue)))
-                .starCount(starCount)
-                .postCount(posts.size())
-                .pickCount(pickers.size())
-                .address(place.getAddress())
-                .zonecode(place.getZonecode())
-                .name(place.getName())
-                .category(place.getCategory())
-                .isPick(isPick)
-                .groupImgIndex(4)
+                .groupName(isPick ? group.getName() : null)
+                .groupImgIndex(isPick ? group.getGroupImgIndex() : 4)
                 .longitude((Double) point[0])
                 .latitude((Double) point[1])
                 .posts(posts)

--- a/server/matp/src/main/java/com/matp/place/service/PlaceService.java
+++ b/server/matp/src/main/java/com/matp/place/service/PlaceService.java
@@ -67,9 +67,9 @@ public class PlaceService {
                     System.out.println(isPick.isPresent());
                     if (isPick.isPresent()) {
                         var group = groupService.findById(isPick.orElseThrow().getPickerGroupId()).block();
-                        return PlaceDetailResponseDto.of(place, posts, pickers, isPick.isPresent(), group);
+                        return PlaceDetailResponseDto.of(place, posts, pickers, true, group);
                     }
-                    return PlaceDetailResponseDto.of(place, posts, pickers, isPick.isPresent());
+                    return PlaceDetailResponseDto.of(place, posts, pickers, false, null);
                 });
     }
 


### PR DESCRIPTION
## What is this PR?(작업 내용) :mag:
- 플레이스 중복 코드 제거
- 포스트 이미지 없을 경우 조회 안되는 에러 해결
- 5점 줄 확률 매핑

## review point :memo:
- 
- 

## Background(문제 배경) 🖼️ 
- 플레이스 조회시 픽의 여부에 따라 거의 유사한 생성자를 각각 호출하여 중복코드가 많았는데 
삼항연산자를 사용하여 그룹 사용 부분만 변경하였습니다
- 플레이스 이미지를 포스트들 중에서 랜덤 인덱스로  가져오는데 포스트가 없을 경우 없는 인덱스를 가져오는 에러가 발생하여 null값으로 넣어줬습니다


## important(같이 논의할 내용) ❓ 
- 
- 
